### PR TITLE
Fix UnicodeDecodeError with python scripts

### DIFF
--- a/conf/add_sso_conf.py
+++ b/conf/add_sso_conf.py
@@ -1,11 +1,11 @@
 import json
 
-with open("/etc/ssowat/conf.json.persistent", "r") as jsonFile:
+with open("/etc/ssowat/conf.json.persistent", "r", encoding='utf-8') as jsonFile:
     data = json.load(jsonFile)
     if "skipped_urls" in data:
         data["skipped_urls"].append("/_matrix")
     else:
         data["skipped_urls"] = ["/_matrix"]
 
-with open("/etc/ssowat/conf.json.persistent", "w") as jsonFile:
+with open("/etc/ssowat/conf.json.persistent", "w", encoding='utf-8') as jsonFile:
     jsonFile.write(json.dumps(data, indent=4, sort_keys=True))

--- a/conf/remove_sso_conf.py
+++ b/conf/remove_sso_conf.py
@@ -1,8 +1,8 @@
 import json
 
-with open("/etc/ssowat/conf.json.persistent", "r") as jsonFile:
+with open("/etc/ssowat/conf.json.persistent", "r", encoding='utf-8') as jsonFile:
     data = json.load(jsonFile)
     data["skipped_urls"].remove("/_matrix")
 
-with open("/etc/ssowat/conf.json.persistent", "w") as jsonFile:
+with open("/etc/ssowat/conf.json.persistent", "w", encoding='utf-8') as jsonFile:
     jsonFile.write(json.dumps(data, indent=4, sort_keys=True))

--- a/scripts/experimental_helper.sh
+++ b/scripts/experimental_helper.sh
@@ -6,7 +6,7 @@
 ynh_read_manifest () {
 	manifest="$1"
 	key="$2"
-	python3 -c "import sys, json;print(json.load(open('$manifest'))['$key'])"
+	python3 -c "import sys, json;print(json.load(open('$manifest', encoding='utf-8'))['$key'])"
 }
 
 # Read the upstream version from the manifest 

--- a/scripts/install
+++ b/scripts/install
@@ -269,7 +269,7 @@ ynh_use_logrotate /var/log/matrix-$app
 # The script "add_sso_conf.py" will just add en entry for the path "/_matrix" in the sso conf.json.persistent file in the cathegory "skipped_urls".
 cp ../conf/add_sso_conf.py $final_path
 cp ../conf/remove_sso_conf.py $final_path
-python $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
+python3 $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
 
 #=================================================
 # SECURE FILES AND DIRECTORIES

--- a/scripts/remove
+++ b/scripts/remove
@@ -64,7 +64,7 @@ closeport $turnserver_alt_tls_port
 #=================================================
 
 # Remove the skipped url
-python $final_path/remove_sso_conf.py
+python3 $final_path/remove_sso_conf.py
 
 #=================================================
 # REMOVE DEPENDENCIES

--- a/scripts/restore
+++ b/scripts/restore
@@ -88,7 +88,7 @@ yunohost firewall allow Both $turnserver_alt_tls_port > /dev/null 2>&1
 
 # Open access to server without a button the home
 # The script "add_sso_conf.py" will just add en entry for the path "/_matrix" in the sso conf.json.persistent file in the cathegory "skipped_urls".
-python $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
+python3 $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
 
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -240,7 +240,7 @@ then
 
     cp ../conf/add_sso_conf.py $final_path
     cp ../conf/remove_sso_conf.py $final_path
-    python $final_path/add_sso_conf.py || echo "Error while sso config, please add '/_matrix' in /etc/ssowat/conf.json.persistent"
+    python3 $final_path/add_sso_conf.py || echo "Error while sso config, please add '/_matrix' in /etc/ssowat/conf.json.persistent"
 
     #=================================================
     # CREATE DEDICATED USER


### PR DESCRIPTION
## The problem

Fix this topic : https://forum.yunohost.org/t/impossible-dinstaller-synapse/4429
To resume if the environment is `LANG=fr_BE@euro` the command `ynh_read_manifest`fail by this log : 
```
+++ python3 -c 'import sys, json;print(json.load(open('\''../manifest.json'\''))['\''version'\''])'
Traceback (most recent call last):
File "", line 1, in
File "/usr/lib/python3.4/json/__init__.py", line 265, in load
return loads(fp.read(),
File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 224: ordinal not in range(128)
```

## Solution

Force python to read the file as `utf-8`. We can do this by adding the option `encoding='utf-8'` in the `open` function.
The other idea is to force to use python3 witch as a better char encoding support.

## PR Status

Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## How to test

Just try to install and remove the app. Set `LANG=fr_BE@euro` in environment to check in the case of the source of this issue.

## Validation

- [x] **Upgrade previous version** : Maniack C
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20fix_manifest_decode%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/APP_ynh%20fix_manifest_decode%20(Official)/)
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.