### PR TITLE
Fix 'PS1: unbound variable' on ARM architecture

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -286,6 +286,11 @@ then
     # We get the last version of the synapse_port_db script because an old version could be buggy.
     cp ../sources/synapse_port_db /opt/yunohost/matrix-synapse/bin/synapse_port_db
 
+    # Fix "PS1: unbound variable" On ARM architecture
+    PS1=""
+    cp ../conf/virtualenv_activate $final_path/bin/activate
+    ynh_replace_string __FINAL_PATH__ $final_path $final_path/bin/activate
+
     # Migrate database (in virtualenv)
     source $final_path/bin/activate
     /opt/yunohost/matrix-synapse/bin/synapse_port_db --sqlite-database /var/lib/matrix-synapse/homeserver.db \


### PR DESCRIPTION
## The problem

The upgrade from the old package on ARM is broken. Actually we get this error : 
```
/opt/yunohost/matrix-synapse/bin/activate: line 57: PS1: unbound variable
```
It's due of the uninitialized variable PS1 while we call the script `activate` [In line 290 of the upgrade script](https://github.com/YunoHost-Apps/synapse_ynh/blob/master/scripts/upgrade#L290)

## Solution

Force to set the variable manually and copy a clean `activate` script as same as [on the install](https://github.com/YunoHost-Apps/synapse_ynh/blob/master/scripts/upgrade#L163-L166).

## PR Status

Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## How to test

Quite difficult to reproduce the issue. The only way is to install synapse_ynh with the branch [old_version](https://github.com/YunoHost-Apps/synapse_ynh/tree/old_version) on ARM board and after to upgrade.

## Validation

- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_upgrade_from_old_version_ARM%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_upgrade_from_old_version_ARM%20(Official)/)
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.