### PR TITLE
Fix pip import

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -100,8 +100,6 @@ test ! -e /etc/matrix-$app/dh.pem && \
 # WARRNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 ynh_install_app_dependencies coturn build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libxml2-dev libxslt1-dev python-lxml libjpeg-dev libpq-dev postgresql acl
-pip install --upgrade pip
-hash -d pip
 pip install --upgrade virtualenv
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -101,6 +101,7 @@ test ! -e /etc/matrix-$app/dh.pem && \
 # For any update do it in all files
 ynh_install_app_dependencies coturn build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libxml2-dev libxslt1-dev python-lxml libjpeg-dev libpq-dev postgresql acl
 pip install --upgrade pip
+hash -d pip
 pip install --upgrade virtualenv
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -60,8 +60,6 @@ ynh_restore
 # WARRNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 ynh_install_app_dependencies coturn build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libxml2-dev libxslt1-dev python-lxml libjpeg-dev libpq-dev postgresql acl
-pip install --upgrade pip
-hash -d pip
 pip install --upgrade virtualenv
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -61,6 +61,7 @@ ynh_restore
 # For any update do it in all files
 ynh_install_app_dependencies coturn build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libxml2-dev libxslt1-dev python-lxml libjpeg-dev libpq-dev postgresql acl
 pip install --upgrade pip
+hash -d pip
 pip install --upgrade virtualenv
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -121,6 +121,7 @@ then
     # For any update do it in all files
     ynh_install_app_dependencies coturn build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libxml2-dev libxslt1-dev python-lxml libjpeg-dev libpq-dev postgresql acl
     pip install --upgrade pip
+    hash -d pip
     pip install --upgrade virtualenv
 
     #=================================================
@@ -172,6 +173,7 @@ else
     # We set all necessary environement variable to create a python virtualenvironnement. 
     source $final_path/bin/activate
     pip install --upgrade pip
+    hash -d pip
     pip install --upgrade setuptools
     pip install --upgrade cffi ndg-httpsclient psycopg2 lxml
     

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -120,8 +120,6 @@ then
     # WARRNING : theses command are used in INSTALL, UPGRADE, RESTORE
     # For any update do it in all files
     ynh_install_app_dependencies coturn build-essential python2.7-dev libffi-dev python-pip python-setuptools sqlite3 libssl-dev python-virtualenv libxml2-dev libxslt1-dev python-lxml libjpeg-dev libpq-dev postgresql acl
-    pip install --upgrade pip
-    hash -d pip
     pip install --upgrade virtualenv
 
     #=================================================
@@ -172,8 +170,6 @@ else
     
     # We set all necessary environement variable to create a python virtualenvironnement. 
     source $final_path/bin/activate
-    pip install --upgrade pip
-    hash -d pip
     pip install --upgrade setuptools
     pip install --upgrade cffi ndg-httpsclient psycopg2 lxml
     


### PR DESCRIPTION
## The problem

With pip 10.0 we have a problem while we call pip after an upgrade. Whe have that after
```
root@yh.lan:# pip install --upgrade pip
Collecting pip
  Downloading https://files.pythonhosted.org/packages/0f/74/ecd13431bcc456ed390b44c8a6e917c1820365cbebcb6a8974d1cd045ab4/pip-10.0.1-py2.py3-none-any.whl (1.3MB)
    100% |████████████████████████████████| 1.3MB 494kB/s 
Installing collected packages: pip
  Found existing installation: pip 9.0.1
    Not uninstalling pip at /usr/lib/python2.7/dist-packages, outside environment /usr
Successfully installed pip-10.0.1
root@yh.lan:/home/admin# pip install --upgrade virtualenv
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
ImportError: cannot import name main
```

The reason of that is that the after the pip upgrade the path is changed ( `/usr/bin/pip` -> `/usr/local/bin/pip`). But bash don't reload the new path and try to load `/usr/bin/pip` and this instance of pip fail by this last error.

## Solution

~~Force bash to reload the best path for pip.~~
Don't upgrade pip in global system.

## PR Status

Not really tested because we have an other issue with synapse actually see (https://github.com/matrix-org/synapse/issues/3135). To fix this we need to upgrade to 0.28.1. ~~I will create an other PR for that, when it's ready.~~ See #46 
We need to fix these both thing to fix this package.

## How to test

Try a new install with pip not upgraded.

## Validation

- [ ] **Upgrade previous version** :
- [ ] **Code review** :
- [ ] **Approval (LGTM)** :
- [ ] **Approval (LGTM)** :
- [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20fix_pip_import%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20fix_pip_import%20(Official)/)
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.