### PR TITLE
V0.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Instant messaging server matrix network.
 
 Yunohost chatroom with matrix : [https://riot.im/app/#/room/#yunohost:matrix.org](https://riot.im/app/#/room/#yunohost:matrix.org)
 
-**Shipped version:** 0.31.0
+**Shipped version:** 0.31.1
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Instant messaging server matrix network.
 
 Yunohost chatroom with matrix : [https://riot.im/app/#/room/#yunohost:matrix.org](https://riot.im/app/#/room/#yunohost:matrix.org)
 
-**Shipped version:** 0.30.0
+**Shipped version:** 0.31.0
 
 Configuration
 -------------

--- a/conf/armv7_jessie.src
+++ b/conf/armv7_jessie.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.31.0/matrix-synapse_0.31.0-jessie-bin1_armv7l.tar.gz
-SOURCE_SUM=49950224115f5720acc645969cebc4f650ab3fa93e6180ea5381ae143bcca222
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.31.1/matrix-synapse_0.31.1-jessie-bin1_armv7l.tar.gz
+SOURCE_SUM=77b12b4135e99da518e0c7910e3f929daf9200cea83ed5853f7712c77435a5bc
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/armv7_jessie.src
+++ b/conf/armv7_jessie.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.30.0/matrix-synapse_0.30.0-jessie-bin1_armv7l.tar.gz
-SOURCE_SUM=4262acb4ff50f743f3766a63771503cbb609e7348a45cb1575c7f9f8ddb9908f
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.31.0/matrix-synapse_0.31.0-jessie-bin1_armv7l.tar.gz
+SOURCE_SUM=49950224115f5720acc645969cebc4f650ab3fa93e6180ea5381ae143bcca222
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/armv7_jessie.src
+++ b/conf/armv7_jessie.src
@@ -1,0 +1,11 @@
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.30.0/matrix-synapse_0.30.0-jessie-bin1_armv7l.tar.gz
+SOURCE_SUM=4262acb4ff50f743f3766a63771503cbb609e7348a45cb1575c7f9f8ddb9908f
+# (Optional) Program to check the integrity (sha256sum, md5sum...)
+# default: sha256
+SOURCE_SUM_PRG=sha256sum
+# (Optional) Archive format
+# default: tar.gz
+SOURCE_FORMAT=tar.gz
+# (Optional) Put false if sources are directly in the archive root
+# default: true
+SOURCE_IN_SUBDIR=true

--- a/conf/armv7_stretch.src
+++ b/conf/armv7_stretch.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.31.0/matrix-synapse_0.31.0-stretch-bin1_armv7l.tar.gz
-SOURCE_SUM=0c5ee84e7f03ff77d5cc1313103a6cf01544bdaff234962649674340dec58f60
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.31.1/matrix-synapse_0.31.1-stretch-bin1_armv7l.tar.gz
+SOURCE_SUM=bed38a43b7e770234f5c3278066316fa261486a885913248c0750088309d87fd
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/armv7_stretch.src
+++ b/conf/armv7_stretch.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.30.0/matrix-synapse_0.30.0-stretch-bin1_armv7l.tar.gz
-SOURCE_SUM=4860a97063c1108672d3ee6845a2c2de1cf646d674a4480315565f2dd5443e34
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.31.0/matrix-synapse_0.31.0-stretch-bin1_armv7l.tar.gz
+SOURCE_SUM=0c5ee84e7f03ff77d5cc1313103a6cf01544bdaff234962649674340dec58f60
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/armv7_stretch.src
+++ b/conf/armv7_stretch.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/Josue-T/synapse_python_build/releases/download/v0.30.0/matrix-synapse_0.30.0-bin1_armv7l.tar.gz
-SOURCE_SUM=ab2cfd893621fc6e7a416af348654b23337639b9654bc2cfb4a19525260f64f3
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v0.30.0/matrix-synapse_0.30.0-stretch-bin1_armv7l.tar.gz
+SOURCE_SUM=4860a97063c1108672d3ee6845a2c2de1cf646d674a4480315565f2dd5443e34
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/python_source.src
+++ b/conf/python_source.src
@@ -1,2 +1,2 @@
-SOURCE_URL=https://github.com/matrix-org/synapse/archive/v0.30.0.tar.gz
-SOURCE_SUM=8c72dc5cf0e194b8326f932add249481b4afb75b7cf6b45337c9fd9606650ca5
+SOURCE_URL=https://github.com/matrix-org/synapse/archive/v0.31.0.tar.gz
+SOURCE_SUM=ee958ae38a2e286db1ed1d15092d7d54a03bda56d4d6174adc729a6720dde6e1

--- a/conf/python_source.src
+++ b/conf/python_source.src
@@ -1,2 +1,2 @@
-SOURCE_URL=https://github.com/matrix-org/synapse/archive/v0.31.0.tar.gz
-SOURCE_SUM=ee958ae38a2e286db1ed1d15092d7d54a03bda56d4d6174adc729a6720dde6e1
+SOURCE_URL=https://github.com/matrix-org/synapse/archive/v0.31.1.tar.gz
+SOURCE_SUM=0408b9f4fc91a90e138c19f0bf9851dcd30c970bd7d6c0bc7a0f498f39b12ac9

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 		"en": "Instant messaging server who use matrix",
 		"fr": "Un serveur de messagerie instantané basé sur matrix"
 	},
-	"version": "0.31.0~ynh1",
+	"version": "0.31.1~ynh1",
 	"url": "http://matrix.org",
 	"license": "Apache-2.0",
 	"maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 		"en": "Instant messaging server who use matrix",
 		"fr": "Un serveur de messagerie instantané basé sur matrix"
 	},
-	"version": "0.30.0~ynh1",
+	"version": "0.31.0~ynh1",
 	"url": "http://matrix.org",
 	"license": "Apache-2.0",
 	"maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -142,12 +142,7 @@ mkdir -p $final_path
 # For any update do it in all files
 if [ -n "$(uname -m | grep arm)" ]
 then
-    if [ "$(lsb_release --codename --short)" == "jessie" ]
-    then
-        ynh_setup_source $final_path/ "armv7_jessie"
-    else
-        ynh_setup_source $final_path/ "armv7_stretch"
-    fi
+    ynh_setup_source $final_path/ "armv7_$(lsb_release --codename --short)"
 else
     # Install virtualenv if it don't exist
     test -e $final_path/bin || virtualenv -p python2.7 $final_path

--- a/scripts/install
+++ b/scripts/install
@@ -142,7 +142,12 @@ mkdir -p $final_path
 # For any update do it in all files
 if [ -n "$(uname -m | grep arm)" ]
 then
-    ynh_setup_source $final_path/ "armv7"
+    if [ "$(lsb_release --codename --short)" == "jessie" ]
+    then
+        ynh_setup_source $final_path/ "armv7_jessie"
+    else
+        ynh_setup_source $final_path/ "armv7_stretch"
+    fi
 else
     # Install virtualenv if it don't exist
     test -e $final_path/bin || virtualenv -p python2.7 $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,12 +82,7 @@ fi
 
 if [ -n "$(uname -m | grep arm)" ]
 then
-    if [ "$(lsb_release --codename --short)" == "jessie" ]
-    then
-        ynh_setup_source $final_path/ "armv7_jessie"
-    else
-        ynh_setup_source $final_path/ "armv7_stretch"
-    fi
+    ynh_setup_source $final_path/ "armv7_$(lsb_release --codename --short)"
 else
     # Install virtualenv if it don't exist
     test -e $final_path/bin || virtualenv -p python2.7 $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,7 +82,12 @@ fi
 
 if [ -n "$(uname -m | grep arm)" ]
 then
-    ynh_setup_source $final_path/ "armv7"
+    if [ "$(lsb_release --codename --short)" == "jessie" ]
+    then
+        ynh_setup_source $final_path/ "armv7_jessie"
+    else
+        ynh_setup_source $final_path/ "armv7_stretch"
+    fi
 else
     # Install virtualenv if it don't exist
     test -e $final_path/bin || virtualenv -p python2.7 $final_path


### PR DESCRIPTION
## Problem
- The app is not up to date with the upstream
- Following the [discussion in the forum](https://forum.yunohost.org/t/synapse-install-bug-cannot-import-name-openssleccurve/4905) I conclude that it's not possible to build a "prebuilt package" for jessie and stretch
- @JimboJoe requested me to move the repos `synapse_python_build` in the `YunoHost-Apps` organisation. (I think too that it's a good idea).

## Solution
- Create a specific build for each debian version.
- Update the app.
- Store all new prebuilt package in the `Yunohost-Apps` organisation.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20v0.31.0%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20v0.31.0%20(Official)/) 
  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
