### PR TITLE
Add network dependance in systemd unit

### DIFF
--- a/conf/matrix-synapse.service
+++ b/conf/matrix-synapse.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Synapse Matrix homeserver
+After=network.target
 
 [Service]
 Type=simple

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -175,10 +175,6 @@ then
 
     yunohost firewall allow Both $turnserver_alt_tls_port > /dev/null 2>&1
 
-    # Configure systemd
-    cp ../conf/default_coturn /etc/default/coturn-$app
-    ynh_add_systemd_config coturn-$app coturn-synapse.service
-
     #=================================================
     # MAKE A CLEAN LOGROTATE CONFIG
     #=================================================
@@ -260,6 +256,17 @@ ynh_store_file_checksum "$coturn_config_path"
 
 cp ../sources/Coturn_config_rotate.sh $final_path/
 ynh_replace_string __APP__ $app "$final_path/Coturn_config_rotate.sh"
+
+#=================================================
+# UPDATE SYSTEMD
+#=================================================
+
+# Create systemd service for synapse and turnserver
+cp ../conf/default_matrix-synapse /etc/default/matrix-$app
+ynh_add_systemd_config matrix-$app matrix-synapse.service
+
+cp ../conf/default_coturn /etc/default/coturn-$app
+ynh_add_systemd_config coturn-$app coturn-synapse.service
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
## Problem
- Synapse don't start correctly if the network stack is not initialised (at the system boot).

## Solution
- Force systemd to start synapse only when the network is up.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_systemd_unit%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_systemd_unit%20(Official)/)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
