### PR TITLE
Config panel

### DIFF
--- a/actions.json
+++ b/actions.json
@@ -7,8 +7,7 @@
         "description": {
             "en": "Update the ip in the turnserver config"
         }
-},
-{
+},{
         "id": "open_turnserver_firewall_ports",
         "name": "Open ports for turnserver",
         "command": "yunohost firewall allow Both 49153:49193",
@@ -16,5 +15,14 @@
         "accepted_return_codes": [0],
         "description": {
             "en": "Open the ports range 49153:49193 with TCP and UDP to be able to use correctly the turnserver."
+        }
+},{
+        "id": "close_turnserver_firewall_ports",
+        "name": "Close ports for turnserver",
+        "command": "yunohost firewall disallow Both 49153:49193",
+        "user": "root",
+        "accepted_return_codes": [0],
+        "description": {
+            "en": "Close the ports range 49153:49193 with TCP and UDP. (Undo \"Open ports for turnserver\" action)"
         }
 }]

--- a/actions.json
+++ b/actions.json
@@ -25,4 +25,23 @@
         "description": {
             "en": "Close the ports range 49153:49193 with TCP and UDP. (Undo \"Open ports for turnserver\" action)"
         }
+},{
+        "id": "set_admin_user",
+        "name": "Set a user as admin",
+        "command": "[[ \"$(su --command=\"psql matrix_synapse\" postgres <<< \"UPDATE users SET admin = 1 WHERE name = '@$YNH_ACTION_USERNAME:$(yunohost app setting $YNH_APP_INSTANCE_NAME special_domain)'\")\" == 'UPDATE 1' ]]",
+        "user": "root",
+        "accepted_return_codes": [0],
+        "description": {
+            "en": "Set a synapse user as admin in the synapse server. It probably usefull only to manage the community function."
+        },
+        "arguments": [
+            {
+                "name": "username",
+                "type": "string",
+                "ask": {
+                    "en": "username of the user to set as admin"
+                },
+                "example": "bob"
+            }
+        ]
 }]

--- a/actions.json
+++ b/actions.json
@@ -1,0 +1,20 @@
+[{
+        "id": "update_turnserver_ip",
+        "name": "Update turnserver ip",
+        "command": "/opt/yunohost/matrix-$YNH_APP_ID/Coturn_config_rotate.sh",
+        "user": "root",
+        "accepted_return_codes": [0],
+        "description": {
+            "en": "Update the ip in the turnserver config"
+        }
+},
+{
+        "id": "open_turnserver_firewall_ports",
+        "name": "Open ports for turnserver",
+        "command": "yunohost firewall allow Both 49153:49193",
+        "user": "root",
+        "accepted_return_codes": [0],
+        "description": {
+            "en": "Open the ports range 49153:49193 with TCP and UDP to be able to use correctly the turnserver."
+        }
+}]

--- a/actions.json
+++ b/actions.json
@@ -1,7 +1,7 @@
 [{
         "id": "update_turnserver_ip",
         "name": "Update turnserver ip",
-        "command": "/opt/yunohost/matrix-$YNH_APP_ID/Coturn_config_rotate.sh",
+        "command": "/opt/yunohost/matrix-$YNH_APP_INSTANCE_NAME/Coturn_config_rotate.sh",
         "user": "root",
         "accepted_return_codes": [0],
         "description": {

--- a/config_panel.json
+++ b/config_panel.json
@@ -1,0 +1,33 @@
+{
+    "name": "Synapse configuration panel",
+    "version": "0.1",
+    "panel": [{
+        "name": "Synapse config",
+        "id": "synapse_config",
+        "sections": [{
+            "name": "Synapse server configuration",
+            "id": "server_config",
+            "options": [{
+                "name": "Server statistics",
+                "id": "server_statistics",
+                "type": "bool",
+                "help": "True to send anonymous statistics about synapse to improve the performances",
+                "default": false
+            }]
+        }]
+    },{
+        "name": "Package config",
+        "id": "package_config",
+        "sections": [{
+            "name": "Synapse server configuration",
+            "id": "package_config",
+            "options": [{
+                "name": "Backup before upgrade",
+                "id": "backup_before_upgrade",
+                "type": "bool",
+                "help": "True to do a backup before every upgrade",
+                "default": false
+            }]
+        }]
+    }]
+}

--- a/config_panel.json
+++ b/config_panel.json
@@ -26,7 +26,7 @@
                 "id": "backup_before_upgrade",
                 "type": "bool",
                 "help": "True to do a backup before every upgrade",
-                "default": false
+                "default": true
             }]
         }]
     }]

--- a/config_panel.json
+++ b/config_panel.json
@@ -13,6 +13,12 @@
                 "type": "bool",
                 "help": "True to send anonymous statistics about synapse to improve the performances",
                 "default": false
+            },{
+                "name": "Server public",
+                "id": "is_public",
+                "type": "bool",
+                "help": "Is it a public server",
+                "default": false
             }]
         }]
     },{

--- a/scripts/config
+++ b/scripts/config
@@ -46,6 +46,7 @@ show_config() {
 
 apply_config() {
     ynh_app_setting_set $app report_stats $YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_SERVER_STATISTICS
+    ynh_replace_string 'report_stats: .*$' "report_stats: $YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_SERVER_STATISTICS" "/etc/matrix-$app/homeserver.yaml"
 
     if ${YNH_CONFIG_PACKAGE_CONFIG_PACKAGE_CONFIG_BACKUP_BEFORE_UPGRADE,,}
     then

--- a/scripts/config
+++ b/scripts/config
@@ -38,6 +38,13 @@ show_config() {
     else
         echo "YNH_CONFIG_PACKAGE_CONFIG_PACKAGE_CONFIG_BACKUP_BEFORE_UPGRADE=True"
     fi
+    is_public=$(ynh_app_setting_get $app is_public)
+    if [[ ${is_public} -eq 1 ]]
+    then
+        echo "YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_IS_PUBLIC=False"
+    else
+        echo "YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_IS_PUBLIC=True"
+    fi
 }
 
 #=================================================
@@ -46,7 +53,6 @@ show_config() {
 
 apply_config() {
     ynh_app_setting_set $app report_stats $YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_SERVER_STATISTICS
-    ynh_replace_string 'report_stats: .*$' "report_stats: $YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_SERVER_STATISTICS" "/etc/matrix-$app/homeserver.yaml"
 
     if ${YNH_CONFIG_PACKAGE_CONFIG_PACKAGE_CONFIG_BACKUP_BEFORE_UPGRADE,,}
     then
@@ -54,6 +60,63 @@ apply_config() {
     else
         ynh_app_setting_set $app disable_backup_before_upgrade 1
     fi
+
+    if ${YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_IS_PUBLIC,,}
+    then
+        ynh_app_setting_set $app is_public 1
+    else
+        ynh_app_setting_set $app is_public 0
+    fi
+
+    domain=$(ynh_app_setting_get $app special_domain)
+    synapse_db_pwd=$(ynh_app_setting_get $app synapse_db_pwd)
+    is_public=$(ynh_app_setting_get $app is_public)
+    port=$(ynh_app_setting_get $app synapse_port)
+    synapse_tls_port=$(ynh_app_setting_get $app synapse_tls_port)
+    turnserver_tls_port=$(ynh_app_setting_get $app turnserver_tls_port)
+    turnserver_pwd=$(ynh_app_setting_get $app turnserver_pwd)
+    registration_shared_secret=$(ynh_app_setting_get $app registration_shared_secret)
+    form_secret=$(ynh_app_setting_get $app form_secret)
+    report_stats=$(ynh_app_setting_get $app report_stats)
+    synapse_user="matrix-$app"
+    synapse_db_name="matrix_$app"
+    synapse_db_user="matrix_$app"
+
+    # Configure Synapse
+
+    # WARNING : theses command are used in INSTALL, UPGRADE, CONFIG (3 times)
+    # For any update do it in all files
+
+    homeserver_config_path="/etc/matrix-$app/homeserver.yaml"
+
+    ynh_backup_if_checksum_is_different "$homeserver_config_path"
+
+    cp ../conf/homeserver.yaml "$homeserver_config_path"
+    cp ../conf/log.yaml /etc/matrix-$app/log.yaml
+
+    ynh_replace_string __APP__ $app "$homeserver_config_path"
+    ynh_replace_string __DOMAIN__ $domain "$homeserver_config_path"
+    ynh_replace_string __SYNAPSE_DB_USER__ $synapse_db_user "$homeserver_config_path"
+    ynh_replace_string __SYNAPSE_DB_PWD__ $synapse_db_pwd "$homeserver_config_path"
+    ynh_replace_string __PORT__ $port "$homeserver_config_path"
+    ynh_replace_string __TLS_PORT__ $synapse_tls_port "$homeserver_config_path"
+    ynh_replace_string __TURNSERVER_TLS_PORT__ $turnserver_tls_port "$homeserver_config_path"
+    ynh_replace_string __TURNPWD__ $turnserver_pwd "$homeserver_config_path"
+    ynh_replace_string __REGISTRATION_SECRET__ "$registration_shared_secret" "$homeserver_config_path"
+    ynh_replace_string __FORM_SECRET__ "$form_secret" "$homeserver_config_path"
+    ynh_replace_string __REPORT_STATS__ "$report_stats" "$homeserver_config_path"
+
+    if [ "$is_public" = "0" ]
+    then
+        ynh_replace_string __ALLOWED_ACCESS__ False "$homeserver_config_path"
+    else
+        ynh_replace_string __ALLOWED_ACCESS__ True "$homeserver_config_path"
+    fi
+
+    ynh_store_file_checksum "$homeserver_config_path"
+    setfacl -R -m user:turnserver:rX  /etc/matrix-$app
+
+    systemctl restart matrix-$app
 }
 
 #=================================================

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC START
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source /usr/share/yunohost/helpers
+
+# Stop script if errors
+ynh_abort_if_errors
+
+# Import common fonctions
+source ./psql.sh
+source ./experimental_helper.sh
+source ./_common.sh
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+app=$YNH_APP_ID
+
+#=================================================
+# SHOW_CONFIG FUNCTION FOR 'SHOW' COMMAND
+#=================================================
+
+show_config() {
+    # here you are supposed to read some config file/database/other then print the values
+    # echo "YNH_CONFIG_${PANEL_ID}_${SECTION_ID}_${OPTION_ID}=value"
+    echo "YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_SERVER_STATISTICS=$(ynh_app_setting_get $app report_stats)"
+
+    backup_before_upgrade=$(ynh_app_setting_get $app disable_backup_before_upgrade)
+    if [[ ${backup_before_upgrade:-0} -eq 1 ]]
+    then
+        echo "YNH_CONFIG_PACKAGE_CONFIG_PACKAGE_CONFIG_BACKUP_BEFORE_UPGRADE=False"
+    else
+        echo "YNH_CONFIG_PACKAGE_CONFIG_PACKAGE_CONFIG_BACKUP_BEFORE_UPGRADE=True"
+    fi
+}
+
+#=================================================
+# MODIFY THE CONFIGURATION
+#=================================================
+
+apply_config() {
+    ynh_app_setting_set $app report_stats $YNH_CONFIG_SYNAPSE_CONFIG_SERVER_CONFIG_SERVER_STATISTICS
+
+    if ${YNH_CONFIG_PACKAGE_CONFIG_PACKAGE_CONFIG_BACKUP_BEFORE_UPGRADE,,}
+    then
+        ynh_app_setting_set $app disable_backup_before_upgrade 0
+    else
+        ynh_app_setting_set $app disable_backup_before_upgrade 1
+    fi
+}
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+# SELECT THE ACTION FOLLOWING THE GIVEN ARGUMENT
+#=================================================
+case $1 in
+    show) show_config;;
+    apply) apply_config;;
+esac

--- a/scripts/config
+++ b/scripts/config
@@ -20,7 +20,7 @@ source ./_common.sh
 # RETRIEVE ARGUMENTS
 #=================================================
 
-app=$YNH_APP_ID
+app=$YNH_APP_INSTANCE_NAME
 
 #=================================================
 # SHOW_CONFIG FUNCTION FOR 'SHOW' COMMAND

--- a/scripts/install
+++ b/scripts/install
@@ -208,7 +208,7 @@ ynh_app_setting_set $app turnserver_pwd $turnserver_pwd
 
 # Configure Synapse
 
-# WARNING : theses command are used in INSTALL, UPGRADE (2 times)
+# WARNING : theses command are used in INSTALL, UPGRADE, CONFIG (3 times)
 # For any update do it in all files
 
 homeserver_config_path="/etc/matrix-$app/homeserver.yaml"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -151,10 +151,13 @@ fi
 # UPDATE SYNAPSE CONFIG
 #=================================================
 
-# WARNING : theses command are used in INSTALL, UPGRADE
+# WARNING : theses command are used in INSTALL, UPGRADE, CONFIG
 # For any update do it in all files
 
 homeserver_config_path="/etc/matrix-$app/homeserver.yaml"
+
+ynh_backup_if_checksum_is_different "$homeserver_config_path"
+ynh_backup_if_checksum_is_different /etc/matrix-$app/log.yaml
 
 cp ../conf/homeserver.yaml "$homeserver_config_path"
 cp ../conf/log.yaml /etc/matrix-$app/log.yaml


### PR DESCRIPTION
## Problem
- To setup correctly the turnserver (open a port range) the user need to use the command line.
- To enable the `report_stats` option in synapse (see #67) the use need to set a specific settings in the app setting.
- To Update the turnserver config the user also need to use the command line.

## Solution
- Use the experimental feature "config panel".
- Use the experimental feature "action".

Note that this branch is based on the branch "new_homeserver_config" (PR #67) because this PR use some new option implemented in the PR #67 

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [ ] **Approval (LGTM)** : 
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20config_panel%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20config_panel%20(Official)/) 

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
