### PR TITLE
Fix coturn config script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -303,9 +303,10 @@ python3 $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-# WARRNING : theses command are used in INSTALL, UPGRADE (2 times), RESTORE
+# WARRNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 chown $synapse_user:root -R $final_path
+chmod 770 $final_path/Coturn_config_rotate.sh
 chown $synapse_user:root -R /var/lib/matrix-$app
 chown $synapse_user:root -R /var/log/matrix-$app
 chown $synapse_user:root -R /etc/matrix-$app

--- a/scripts/restore
+++ b/scripts/restore
@@ -173,6 +173,7 @@ ynh_use_logrotate /var/log/matrix-$app
 # WARNING : these commands are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 chown $synapse_user:root -R $final_path
+chmod 770 $final_path/Coturn_config_rotate.sh
 chown $synapse_user:root -R /var/lib/matrix-$app
 chown $synapse_user:root -R /var/log/matrix-$app
 chown $synapse_user:root -R /etc/matrix-$app

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -274,9 +274,10 @@ ynh_add_systemd_config coturn-$app coturn-synapse.service
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-# WARRNING : theses command are used in INSTALL, UPGRADE (2 times), RESTORE
+# WARRNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 chown $synapse_user:root -R $final_path
+chmod 770 $final_path/Coturn_config_rotate.sh
 chown $synapse_user:root -R /var/lib/matrix-$app
 chown $synapse_user:root -R /var/log/matrix-$app
 chown $synapse_user:root -R /etc/matrix-$app

--- a/sources/Coturn_config_rotate.sh
+++ b/sources/Coturn_config_rotate.sh
@@ -25,6 +25,8 @@ fi
 
 ynh_replace_string "^external-ip=.*\$" "$external_IP_line" "/etc/matrix-$app_instance/coturn.conf"
 
-setfacl -R -m user:turnserver:rX  /etc/matrix-$app
+setfacl -R -m user:turnserver:rX  /etc/matrix-$app_instance
+
+systemctl restart coturn-$app_instance.service
 
 exit 0

--- a/sources/Coturn_config_rotate.sh
+++ b/sources/Coturn_config_rotate.sh
@@ -25,4 +25,6 @@ fi
 
 ynh_replace_string "^external-ip=.*\$" "$external_IP_line" "/etc/matrix-$app_instance/coturn.conf"
 
+setfacl -R -m user:turnserver:rX  /etc/matrix-$app
+
 exit 0


### PR DESCRIPTION
## Problem
- The Coturn update config script don't work really well.

## Solution
- Set the permission to the coturn config file in the update script (I discovered that while we update the file we lost the acl).
- Set the file executable (it's more intiutive to call `/opt/yunohost/matrix-synapse/Coturn_config_rotate.sh` than some thing like `bash /opt/yunohost/matrix-synapse/Coturn_config_rotate.sh`).

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_coturn_config_script%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_coturn_config_script%20(Official)/)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
