### PR TITLE
Fix PS1 variable in upgrade script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -141,7 +141,7 @@ else
     test -e $final_path/bin || virtualenv -p python2.7 $final_path
 
     # Install synapse in virtualenv
-    PS1=""
+    PS1=${PS1:-}
     cp ../conf/virtualenv_activate $final_path/bin/activate
     ynh_replace_string __FINAL_PATH__ $final_path $final_path/bin/activate
 
@@ -168,6 +168,7 @@ fi
 #=================================================
 
 # Go in virtualenvironnement
+PS1=${PS1:-}
 source $final_path/bin/activate
 
 # Get the dh.pem if exist

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,7 +91,7 @@ else
     test -e $final_path/bin || virtualenv -p python2.7 $final_path
 
     # Install synapse in virtualenv
-    PS1=""
+    PS1=${PS1:-}
     cp ../conf/virtualenv_activate $final_path/bin/activate
     ynh_replace_string __FINAL_PATH__ $final_path $final_path/bin/activate
 
@@ -120,6 +120,7 @@ fi
 if [[ -z "$registration_shared_secret" ]]
 then
     # Go in virtualenvironnement
+    PS1=${PS1:-}
     source $final_path/bin/activate
 
     # Get the dh.pem if exist


### PR DESCRIPTION
## Problem
- On ARM (and mybe some others arch) when we call `source $final_path/bin/activate` the activate script use the variable PS1 but is not defined before.

## Solution
- Just set it as an empty variable if not defined.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_PS1%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20Fix_PS1%20(Official)/) 

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
