### PR TITLE
Fix venv setup

### DIFF
--- a/conf/virtualenv_activate
+++ b/conf/virtualenv_activate
@@ -28,7 +28,7 @@ deactivate () {
     fi
 
     unset VIRTUAL_ENV
-    if [ ! "$1" = "nondestructive" ] ; then
+    if [ ! "${1:-}" = "nondestructive" ] ; then
     # Self destruct!
         unset -f deactivate
     fi

--- a/conf/virtualenv_activate
+++ b/conf/virtualenv_activate
@@ -2,17 +2,14 @@
 # you cannot run it directly
 
 deactivate () {
-    unset -f pydoc >/dev/null 2>&1
-
     # reset old environment variables
-    # ! [ -z ${VAR+_} ] returns true if VAR is declared at all
-    if ! [ -z "${_OLD_VIRTUAL_PATH+_}" ] ; then
-        PATH="$_OLD_VIRTUAL_PATH"
+    if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
+        PATH="${_OLD_VIRTUAL_PATH:-}"
         export PATH
         unset _OLD_VIRTUAL_PATH
     fi
-    if ! [ -z "${_OLD_VIRTUAL_PYTHONHOME+_}" ] ; then
-        PYTHONHOME="$_OLD_VIRTUAL_PYTHONHOME"
+    if [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
+        PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
         export PYTHONHOME
         unset _OLD_VIRTUAL_PYTHONHOME
     fi
@@ -20,18 +17,18 @@ deactivate () {
     # This should detect bash and zsh, which have a hash command that must
     # be called to get it to forget past commands.  Without forgetting
     # past commands the $PATH changes we made may not be respected
-    if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
-        hash -r 2>/dev/null
+    if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
+        hash -r
     fi
 
-    if ! [ -z "${_OLD_VIRTUAL_PS1+_}" ] ; then
-        PS1="$_OLD_VIRTUAL_PS1"
+    if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
+        PS1="${_OLD_VIRTUAL_PS1:-}"
         export PS1
         unset _OLD_VIRTUAL_PS1
     fi
 
     unset VIRTUAL_ENV
-    if [ ! "${1-}" = "nondestructive" ] ; then
+    if [ ! "$1" = "nondestructive" ] ; then
     # Self destruct!
         unset -f deactivate
     fi
@@ -48,31 +45,32 @@ PATH="$VIRTUAL_ENV/bin:$PATH"
 export PATH
 
 # unset PYTHONHOME if set
-if ! [ -z "${PYTHONHOME+_}" ] ; then
-    _OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
+# this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
+# could use `if (set -u; : $PYTHONHOME) ;` in bash
+if [ -n "${PYTHONHOME:-}" ] ; then
+    _OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
     unset PYTHONHOME
 fi
 
-if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
-    _OLD_VIRTUAL_PS1="$PS1"
-    if [ "x" != x ] ; then
-        PS1="$PS1"
+if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
+    _OLD_VIRTUAL_PS1="${PS1:-}"
+    if [ "x(new) " != x ] ; then
+	PS1="(new) ${PS1:-}"
     else
-        PS1="(`basename \"$VIRTUAL_ENV\"`) $PS1"
+    if [ "`basename \"$VIRTUAL_ENV\"`" = "__" ] ; then
+        # special case for Aspen magic directories
+        # see http://www.zetadev.com/software/aspen/
+        PS1="[`basename \`dirname \"$VIRTUAL_ENV\"\``] $PS1"
+    else
+        PS1="(`basename \"$VIRTUAL_ENV\"`)$PS1"
+    fi
     fi
     export PS1
 fi
 
-# Make sure to unalias pydoc if it's already there
-alias pydoc 2>/dev/null >/dev/null && unalias pydoc
-
-pydoc () {
-    python -m pydoc "$@"
-}
-
 # This should detect bash and zsh, which have a hash command that must
 # be called to get it to forget past commands.  Without forgetting
 # past commands the $PATH changes we made may not be respected
-if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
-    hash -r 2>/dev/null
+if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
+    hash -r
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -140,7 +140,6 @@ else
     test -e $final_path/bin/python3 || python3 -m venv $final_path
 
     # Install synapse in virtualenv
-    PS1=${PS1:-}
     cp ../conf/virtualenv_activate $final_path/bin/activate
     ynh_replace_string __FINAL_PATH__ $final_path $final_path/bin/activate
 

--- a/scripts/install
+++ b/scripts/install
@@ -93,7 +93,6 @@ ynh_app_setting_set $app cli_port $cli_port
 # WARNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 ynh_install_app_dependencies $dependances
-pip3 install --upgrade virtualenv
 
 #=================================================
 # CREATE DEDICATED USER

--- a/scripts/restore
+++ b/scripts/restore
@@ -60,7 +60,6 @@ ynh_restore
 # WARNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 ynh_install_app_dependencies  $dependances
-pip install --upgrade virtualenv
 
 #=================================================
 # RECREATE THE DEDICATED USER

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -102,7 +102,6 @@ else
     test -e $final_path/bin/python3 || python3 -m venv $final_path
 
     # Install synapse in virtualenv
-    PS1=${PS1:-}
     cp ../conf/virtualenv_activate $final_path/bin/activate
     ynh_replace_string __FINAL_PATH__ $final_path $final_path/bin/activate
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -81,7 +81,6 @@ fi
 # WARNING : theses command are used in INSTALL, UPGRADE, RESTORE
 # For any update do it in all files
 ynh_install_app_dependencies $dependances
-pip3 install --upgrade virtualenv
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
## Problem
- While we migrate to python3 we replaced `virtualenv` by `venv` (which is an other tools to manage venv. `virtualenv` not needed any more.
- The "activate" script come from the virtualenv package

## Solution
- Don't install `virtualenv`
- Use the venv "activate" script

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20fix_python_venv%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/synapse_ynh%20fix_python_venv%20(Official)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
