### PR TITLE
Use the sso script directly from the config directroy

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,13 +3,13 @@
 	"id": "synapse",
 	"packaging_format": 1,
 	"requirements": {
-		"yunohost": ">= 2.7.14"
+		"yunohost": ">= 3.5.0"
 	},
 	"description": {
 		"en": "Instant messaging server who use matrix",
 		"fr": "Un serveur de messagerie instantané basé sur matrix"
 	},
-	"version": "0.99.3~ynh1",
+	"version": "0.99.3~ynh2",
 	"url": "http://matrix.org",
 	"license": "Apache-2.0",
 	"maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -313,9 +313,7 @@ ynh_replace_string __APP__ $app "$final_path/Coturn_config_rotate.sh"
 
 # Open access to server without a button the home
 # The script "add_sso_conf.py" will just add en entry for the path "/_matrix" in the sso conf.json.persistent file in the cathegory "skipped_urls".
-cp ../conf/add_sso_conf.py $final_path
-cp ../conf/remove_sso_conf.py $final_path
-python3 $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
+python3 ../conf/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
 
 #=================================================
 # SECURE FILES AND DIRECTORIES

--- a/scripts/install
+++ b/scripts/install
@@ -313,7 +313,7 @@ ynh_replace_string __APP__ $app "$final_path/Coturn_config_rotate.sh"
 
 # Open access to server without a button the home
 # The script "add_sso_conf.py" will just add en entry for the path "/_matrix" in the sso conf.json.persistent file in the cathegory "skipped_urls".
-python3 ../conf/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
+python3 ../conf/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent doesn't respect the json syntax. Please fix the syntax to install this app. For more information see here: https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
 
 #=================================================
 # SECURE FILES AND DIRECTORIES

--- a/scripts/remove
+++ b/scripts/remove
@@ -64,7 +64,7 @@ closeport $turnserver_alt_tls_port
 #=================================================
 
 # Remove the skipped url
-python3 $final_path/remove_sso_conf.py
+python3 ../conf/remove_sso_conf.py
 
 #=================================================
 # REMOVE DEPENDENCIES

--- a/scripts/restore
+++ b/scripts/restore
@@ -148,7 +148,7 @@ yunohost firewall allow Both $turnserver_alt_tls_port > /dev/null 2>&1
 
 # Open access to server without a button the home
 # The script "add_sso_conf.py" will just add en entry for the path "/_matrix" in the sso conf.json.persistent file in the cathegory "skipped_urls".
-python3 ../settings/conf/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
+python3 ../settings/conf/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent doesn't respect the json syntax. Please fix the syntax to install this app. For more information see here: https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
 
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -148,7 +148,7 @@ yunohost firewall allow Both $turnserver_alt_tls_port > /dev/null 2>&1
 
 # Open access to server without a button the home
 # The script "add_sso_conf.py" will just add en entry for the path "/_matrix" in the sso conf.json.persistent file in the cathegory "skipped_urls".
-python3 $final_path/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
+python3 ../settings/conf/add_sso_conf.py || ynh_die "Your file /etc/ssowat/conf.json.persistent don't respect the json synaxe. Please fix the synaxe to install this app. For more information see here : https://github.com/YunoHost-Apps/synapse_ynh/issues/32"
 
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE


### PR DESCRIPTION
## Problem
- In the upgrade script when we migrate to python 3 we clean the directory `$final_path`. So the sso script `remove_sso_conf.py` and `add_sso_conf.py` is removed. But in the upgrade script these script is not more copied.

So if the user call after the remove script or the restore script these script are not found.

## Solution

- Call directly theses script from the `conf` directory. The idea to save theses script to the `$final_path` directory was implemented when the conf directory was not saved.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : Anmol
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR122/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR122/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
