### PR TITLE
Fix typo in IP6 validation

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -122,7 +122,7 @@ else
     ynh_replace_string '__IPV4__,' "" "$coturn_config_path"
 fi
 
-if [[ -n "$public_ip6" ]] && ynh_valide_ip6 "$public_ip6"
+if [[ -n "$public_ip6" ]] && ynh_validate_ip6 "$public_ip6"
 then
     ynh_replace_string '__IPV6__' "$public_ip6" "$coturn_config_path"
 else


### PR DESCRIPTION
## Problem
- Fixed a typo making IP6 validation fail.

## Solution
- Fixed a typo.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR137/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR137/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
