### PR TITLE
Update URL of the federation's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ _matrix._tcp.example.com. 3600    IN      SRV     10 0 SYNAPSE_PORT synapse.exam
 ```
 You need to replace SYNAPSE_PORT by the real port. This port can be obtained by the command: `yunohost app setting SYNAPSE_INSTANCE_NAME synapse_tls_port`
 
-For more details, see : https://github.com/matrix-org/synapse#setting-up-federation
+For more details, see : https://github.com/matrix-org/synapse/blob/master/docs/federate.md
 
 If it is not automatically done, you need to open this in your ISP box.
 


### PR DESCRIPTION
The URL has changed

## Problem
- The federation's documentation has a new URL

## Solution
- Change the URL in the README.md

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Josué
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR179/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR179/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
