### PR TITLE
Use vector identity server to send email dans SMS

### DIFF
--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -906,7 +906,7 @@ registration_shared_secret: "__REGISTRATION_SECRET__"
 # (By default, no suggestion is made, so it is left up to the client.
 # This setting is ignored unless public_baseurl is also set.)
 #
-#default_identity_server: https://matrix.org
+default_identity_server: https://vector.im
 
 # The list of identity servers trusted to verify third party
 # identifiers by this server.
@@ -949,8 +949,8 @@ registration_shared_secret: "__REGISTRATION_SECRET__"
 # If a delegate is specified, the config option public_baseurl must also be filled out.
 #
 account_threepid_delegates:
-    #email: https://example.com     # Delegate email sending to example.org
-    #msisdn: http://localhost:8090  # Delegate SMS sending to this local process
+    email: https://vector.im     # Delegate email sending to vector.im # TODO use the Yunohost server to send email !!
+    msisdn: https://vector.im
 
 # Users who register on this homeserver will automatically be joined
 # to these rooms


### PR DESCRIPTION
## Problem
- We can't register a new phone number in riot
- No identity server is defined by default
- https://github.com/YunoHost-Apps/synapse_ynh/issues/171

## Solution
- Use the vector.im server for phone number
- Use the vector.im server for email temporary. In long term we will use the Yunohost server.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR186/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR186/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
