### PR TITLE
correct rights for bridge registration and correct app action

### DIFF
--- a/sources/update_synapse_for_appservice.sh
+++ b/sources/update_synapse_for_appservice.sh
@@ -9,6 +9,7 @@ cp $service_config_file /tmp/app_service_backup.yaml
 echo "app_service_config_files:" > $service_config_file
 for f in $(ls /etc/matrix-$app/app-service/); do
     echo "  - /etc/matrix-$app/app-service/$f" >> $service_config_file
+    chmod 600 /etc/matrix-$app/app-service/$f
 done
 
 # Set permissions

--- a/sources/update_synapse_for_appservice.sh
+++ b/sources/update_synapse_for_appservice.sh
@@ -12,7 +12,7 @@ for f in $(ls /etc/matrix-$app/app-service/); do
 done
 
 # Set permissions
-chown matrix-$app $service_config_file
+chown -R /etc/matrix-$app --reference=$service_config_file
 chmod 600 $service_config_file
 
 systemctl restart matrix-$app

--- a/sources/update_synapse_for_appservice.sh
+++ b/sources/update_synapse_for_appservice.sh
@@ -12,7 +12,7 @@ for f in $(ls /etc/matrix-$app/app-service/); do
 done
 
 # Set permissions
-chown -R /etc/matrix-$app --reference=$service_config_file
+chown --reference=$service_config_file -R /etc/matrix-$app 
 chmod 600 $service_config_file
 
 systemctl restart matrix-$app
@@ -22,5 +22,5 @@ if [ $? -eq 0 ]; then
     exit 0
 else
     echo "Failed to restart synapse with the new config file. Restore the old config file !!"
-    cp /tmp/app_service_backup.yaml $service_config_file
+    mv /tmp/app_service_backup.yaml $service_config_file
 fi


### PR DESCRIPTION
## Problem
- wrong access rights to registration file after calling registration script
- app action to set admin rights to bot in synapse DB still not working

## Solution
- set rights recursive
- 

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
