### PR TITLE
Riot was renamed to element

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The script to build the binary is also available.
 
 ### Web client
 
-If you want a web client you can also install riot with this package: https://github.com/YunoHost-Apps/riot_ynh .
+If you want a web client you can also install riot with this package: https://github.com/YunoHost-Apps/element_ynh .
 
 ### Access by federation
 


### PR DESCRIPTION
Change the link from riot to element.

## Problem
The referred project was renamed. 

## Solution
New URL

## PR Status
No code, just README.md

From here on I don't know what I need to do. :-) 

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR-219-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/synapse_ynh%20PR-219-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
