### PR TITLE
Update pip instead of installing Rust to fetch `cryptography` wheel

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -29,15 +29,6 @@ install_sources() {
             fi
         done
     else
-        # Install rustup is not already installed
-        # We need this to be able to install cryptgraphy
-        export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin"
-        if [ -e $final_path/.rustup ]; then
-            sudo -u "$synapse_user" env PATH=$PATH rustup update
-        else
-            sudo -u "$synapse_user" bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=stable'
-        fi
-    
         # Install virtualenv if it don't exist
         test -e $final_path/bin/python3 || python3 -m venv $final_path
 
@@ -47,7 +38,7 @@ install_sources() {
         set +u;
         source $final_path/bin/activate
         set -u;
-        pip3 install --upgrade setuptools wheel
+        pip3 install --upgrade setuptools wheel pip
         chown $synapse_user:root -R $final_path
         sudo -u $synapse_user env PATH=$PATH pip3 install --upgrade 'cryptography>=3.3'
         pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml jinja2


### PR DESCRIPTION
## Problem
- I encountered issue #236 while trying to restore a synapse backup.
- The problem was introduced by a recent breaking change in the upstream python `cryptography` package. 
- The current solution in #238 installs the Rust toolchain but this is not required.

## Solution
- `cryptography`'s maintainers have discussed the issue at length with their community (([original issue](https://github.com/pyca/cryptography/issues/5771#issuecomment-775990406))
) and suggest updating `pip` first to benefit from the pre-built wheel package instead of building from source with Rust 

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
