### PR TITLE
Remove only virtual environment file in `install_sources`

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,12 @@ install_sources() {
 
     # Clean venv is it was on python2.7 or python3 with old version in case major upgrade of debian
     if [ ! -e $final_path/bin/python3 ] || [ ! -e $final_path/lib/python$python_version ]; then
-        ynh_secure_remove --file=$final_path
+        ynh_secure_remove --file=$final_path/bin
+        ynh_secure_remove --file=$final_path/lib
+        ynh_secure_remove --file=$final_path/lib64
+        ynh_secure_remove --file=$final_path/include
+        ynh_secure_remove --file=$final_path/share
+        ynh_secure_remove --file=$final_path/pyvenv.cfg
     fi
 
     mkdir -p $final_path


### PR DESCRIPTION
## Problem
- The `install_sources` function removes the whole `$final_path` folder in an attempt to clear a previous virtual environment
- This can be problematic in case other files were present that had nothing to do with the virtual environment
- For instance, I was not able to restore a backup due to `install_sources` removing files that had been previously restored. Example of such files that were deleted along the virtual env:
  - `/opt/yunohost/matrix-synapse/update_synapse_for_appservice.sh`
  - `/opt/yunohost/matrix-synapse/remove_sso_conf.py`
  - `/opt/yunohost/matrix-synapse/Coturn_config_rotate.sh`

## Solution
- Updated the cleaning procedure to remove only the files created by virtual environment
- A better solution would be to create the virtual environment in its own subfolder, or to dedicate `/opt/yunohost/matrix-synapse/` for the venv and move the other scripts to another location
- I'll let you judge what is the best option

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
