### PR TITLE
Force version for Twisted (fixes #246)

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -51,7 +51,7 @@ install_sources() {
         chown $synapse_user:root -R $final_path
         sudo -u $synapse_user env PATH=$PATH pip3 install --upgrade 'cryptography>=3.3'
         pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml jinja2
-        pip3 install --upgrade 'Twisted>=20.3.0' matrix-synapse==$upstream_version matrix-synapse-ldap3
+        pip3 install --upgrade 'Twisted==20.3.0' matrix-synapse==$upstream_version matrix-synapse-ldap3
 
         # This function was defined when we called "source $final_path/bin/activate". With this function we undo what "$final_path/bin/activate" does
         set +u;


### PR DESCRIPTION
## Problem
- See https://github.com/YunoHost-Apps/synapse_ynh/issues/246

## Solution
- Enforce the twisted version


## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

I am not sure how to follow all of this, and I am sorry I lack of time.
Don't hesitate to close this PR and do that properly. 

## Rationals

When I install Twisted from pip using the following command:
```bash
pip3 install --user 'Twisted>=20.3.0'
```

I may actually get version 21.2.0 of the lib.

If I run :
```
$ python3
>>>from twisted.python.compat import _PY3, unicode
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name '_PY3' from 'twisted.python.compat' (unknown location)
```

It seems that Twisted introduced some breaking changes, because this error does not exist in 20.3.0.

Therefore I propose to use a strict version of Twisted.