### PR TITLE
Add X-Forwarded-Proto header

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,6 +1,7 @@
 location __PATH__ {
         proxy_pass http://localhost:__PORT__;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
         client_max_body_size 100M;
 


### PR DESCRIPTION
Fixes https://github.com/YunoHost-Apps/synapse_ynh/issues/249

## Problem
- Synapse doesn't know we forwarded https, logs get noisy due to this

## Solution
- Add `X-Forwarded-Proto` to nginx config

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.
