### PR TITLE
Fix server_client_infos permission configuration

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -424,7 +424,7 @@ if yunohost --output-as plain domain list | grep -q "^$server_name"'$' && ! ynh_
     ynh_permission_create --permission=server_client_infos --url=$server_name/.well-known/matrix \
                           --label="Server info for clients. (well-known)" --show_tile=false --allowed=visitors \
                           --auth_header=false --protected=true
-else
+elif yunohost --output-as plain domain list | grep -q "^$server_name"'$'; then
     ynh_permission_url --permission=server_client_infos --url=$server_name/.well-known/matrix \
                        --auth_header=false
     ynh_permission_update --permission=server_client_infos --label="Server info for clients. (well-known)" --show_tile=false \


### PR DESCRIPTION
## Problem

This fixes https://github.com/YunoHost-Apps/synapse_ynh/issues/259

## Solution

When upgrading the app, the `server_client_infos` permission should not be configured if the the .well-known is hosted on a third party server.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
