### PR TITLE
Switch to matrix.to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Instant messaging server matrix network.
 
-YunoHost chatroom with Matrix : [https://matrix.to/#/#yunohost:libera.chat](https://matrix.to/#/#yunohost:libera.chat)
+YunoHost chatroom with Matrix : [https://matrix.to/#/#yunohost:matrix.org](https://matrix.to/#/#yunohost:matrix.org)
 
 
 **Shipped version:** 1.67.0~ynh1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Instant messaging server matrix network.
 
-Yunohost chatroom with matrix : [https://riot.im/app/#/room/#yunohost:matrix.org](https://riot.im/app/#/room/#yunohost:matrix.org)
+Yunohost chatroom with matrix : [https://matrix.to/#/#yunohost:libera.chat](https://matrix.to/#/#yunohost:libera.chat)
 
 
 **Shipped version:** 1.67.0~ynh1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Instant messaging server matrix network.
 
-Yunohost chatroom with matrix : [https://matrix.to/#/#yunohost:libera.chat](https://matrix.to/#/#yunohost:libera.chat)
+YunoHost chatroom with Matrix : [https://matrix.to/#/#yunohost:libera.chat](https://matrix.to/#/#yunohost:libera.chat)
 
 
 **Shipped version:** 1.67.0~ynh1

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,3 +1,3 @@
 Instant messaging server matrix network.
 
-Yunohost chatroom with matrix : [https://riot.im/app/#/room/#yunohost:matrix.org](https://riot.im/app/#/room/#yunohost:matrix.org)
+Yunohost chatroom with matrix : [https://matrix.to/#/#yunohost:matrix.org](https://matrix.to/#/#yunohost:matrix.org)


### PR DESCRIPTION
The matrix.to site allows users to click matrix links into many clients, while the previous link is the web version of the riot.im client, which I think has by now been renamed to element also.