### PR TITLE
Fix issue with jinja2 dependency

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -48,7 +48,7 @@ install_sources() {
         pip3 install --upgrade setuptools wheel pip
         chown $synapse_user:root -R $final_path
         sudo -u $synapse_user env PATH=$PATH pip3 install --upgrade 'cryptography>=3.4.7'
-        pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml jinja2
+        pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml 'jinja2==3.0.3'
         # Fix issue https://github.com/YunoHost-Apps/synapse_ynh/issues/248
         pip3 install --upgrade 'Twisted>=21' 'treq>=21.1.0' matrix-synapse==$upstream_version matrix-synapse-ldap3
 


### PR DESCRIPTION
## Problem

Error in CI: https://ci-apps-dev.yunohost.org/ci/job/657

```
1459129 WARNING     def safe_markup(raw_html: str) -> jinja2.Markup:
1459131 WARNING AttributeError: module 'jinja2' has no attribute 'Markup'
1460886 ERROR Unable to install synapse: An error occurred inside the app installation script
1460888 INFO The operation 'Install the 'synapse' app' could not be completed. Please share the full log of this operation using the command 'yunohost log share 20220423-224355-app_install-synapse' to get help
1460982 WARNING Here's an extract of the logs before the crash. It might help debugging the error:
```

## Solution

- I suggest to fix the jinja2 version to version 3.0.3
- Maybe [this PR](https://github.com/YunoHost-Apps/synapse_ynh/pull/308) can also help fixing this issue, and we may change the version dependency later

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
