### PR TITLE
Upgrade synapse to 1.59.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Instant messaging server matrix network.
 Yunohost chatroom with matrix : [https://riot.im/app/#/room/#yunohost:matrix.org](https://riot.im/app/#/room/#yunohost:matrix.org)
 
 
-**Shipped version:** 1.59.0~ynh1
+**Shipped version:** 1.59.1~ynh1
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -16,7 +16,7 @@ Instant messaging server matrix network.
 Yunohost chatroom with matrix : [https://riot.im/app/#/room/#yunohost:matrix.org](https://riot.im/app/#/room/#yunohost:matrix.org)
 
 
-**Version incluse :** 1.59.0~ynh1
+**Version incluse :** 1.59.1~ynh1
 
 
 

--- a/conf/armv7_bullseye.src
+++ b/conf/armv7_bullseye.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v1.59.0/matrix-synapse_1.59.0-bullseye-bin1_armv7l.tar.gz
-SOURCE_SUM=aedd3fe868dc9ad9359da0ce5124c602945267e9ab69a5ed0249367391cd44e7
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v1.59.1/matrix-synapse_1.59.1-bullseye-bin1_armv7l.tar.gz
+SOURCE_SUM=b4a5435609cc679c3e9e10f437020d2a96077f227cd46b67470008a2f7f2f8f4
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/armv7_buster.src
+++ b/conf/armv7_buster.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v1.59.0/matrix-synapse_1.59.0-buster-bin1_armv7l.tar.gz
-SOURCE_SUM=3a1e4602507594d4a38c5613edd1e16ebeef6e67cb7d40a7847fb0a32aeade22
+SOURCE_URL=https://github.com/YunoHost-Apps/synapse_python_build/releases/download/v1.59.1/matrix-synapse_1.59.1-buster-bin1_armv7l.tar.gz
+SOURCE_SUM=9416fa0cec0b8810c4e054545c712ffdd2205bafadced3f636fc1883fa1065c2
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "Instant messaging server which uses Matrix",
 		"fr": "Un serveur de messagerie instantané basé sur Matrix"
 	},
-	"version": "1.59.0~ynh1",
+	"version": "1.59.1~ynh1",
 	"url": "http://matrix.org",
 	"license": "Apache-2.0",
 	"maintainer": {


### PR DESCRIPTION
## Problem

- Synapse is outdated
- I am hit by bug https://github.com/matrix-org/synapse/issues/12755 (https://github.com/matrix-org/synapse/issues/12763), fixed in https://github.com/matrix-org/synapse/pull/12762 and released in 1.59.1; this made my synapse log grow to 100G in no time.

## Solution

- upgrade package

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
