### PR TITLE
Improve syncing of big accounts: add caching, increase timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ After that you can install it without problem.
 The package uses a prebuilt python virtual environnement. The binary are taken from this repository: https://github.com/Josue-T/synapse_python_build
 The script to build the binary is also available.
 
+### Performance Tuning
+
+Depending on the amount of RAM on your système, you might want to tune the cache configuration in `/etc/matrix-synapse/homeserver.yaml`.
+
 ### Web client
 
 If you want a web client you can also install Element with this package: https://github.com/YunoHost-Apps/element_ynh .

--- a/README_fr.md
+++ b/README_fr.md
@@ -35,6 +35,10 @@ After that you can install it without problem.
 The package uses a prebuilt python virtual environnement. The binary are taken from this repository: https://github.com/Josue-T/synapse_python_build
 The script to build the binary is also available.
 
+### Amélioration de la performance
+
+En fonction de la quantité de RAM de votre système, vous voudrez peut-être augmenter ou diminuer la taille des caches dans `/etc/matrix-synapse/homeserver.yaml`
+
 ### Web client
 
 If you want a web client you can also install Element with this package: https://github.com/YunoHost-Apps/element_ynh .

--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -817,6 +817,33 @@ database:
   #args:
     #database: /root/homeserver.db
 
+caches:
+  # Controls the global cache factor, which is the default cache factor
+  # for all caches if a specific factor for that cache is not otherwise
+  # set.
+  #
+  # This can also be set by the "SYNAPSE_CACHE_FACTOR" environment
+  # variable. Setting by environment variable takes priority over
+  # setting through the config file.
+  #
+  # Defaults to 0.5, which will half the size of all caches.
+  #
+  # global_factor: 2.0
+
+  # Controls how long an entry can be in a cache without having been
+  # accessed before being evicted. Defaults to None, which means
+  # entries are never evicted based on time.
+  #
+  # expiry_time: 120m
+
+  # Controls how long the results of a /sync request are cached for after
+  # a successful response is returned. A higher duration can help clients with
+  # intermittent connections, at the cost of higher memory usage.
+  #
+  # By default, this is zero, which means that sync responses are not cached
+  # at all.
+  #
+  sync_response_cache_duration: 15m
 
 ## Logging ##
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -6,6 +6,12 @@ location __PATH__/ {
 
         client_max_body_size 100M;
 
+        # Use longer timeouts for the sync API
+        location __PATH__/client/r0/sync {
+            proxy_read_timeout 7m;
+            proxy_pass http://localhost:__PORT__;
+        }
+
         # Use the specific path for the php file. It's more secure than global php path
         location __PATH__/cas_server.php {
             alias /var/www/__APP__/;


### PR DESCRIPTION
## Problem

- My Matrix account is quite big. Even on a 8-core xeon E31270 x86_64 cpu and 32 GB of RAM, I run into timeouts during initial sync and subsequent syncs with the default config.
- With the default config, running into an nginx timeout (default 60s) means that the sync computation is thrown away, and the server starts from scratch: https://github.com/matrix-org/synapse/issues/3880 https://github.com/matrix-org/synapse/issues/13027

## Solution

- Increase the default nginx timeout for the sync endpoint, from 60s. 7 minutes is arbitrary, but should provide a lot more time for syncing before it is attempted again, while still being a reasonable waiting time for big accounts.
- Introduce caching of sync response. If connection is cut while syncing, the server doesn't have to re-compute everything. This will use slightly more memory (but not that much, it seems). It can also be disabled in the config.

I also left commented out other caching options I use as I have plenty of RAM. The comments are taken from upstream homeserver.yaml. This should make it easier for curious user to play with cache settings, and can be activated by default at a later time.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
