### PR TITLE
fix(conf): start a new line for each domain to whitelist

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -51,7 +51,7 @@ install_sources() {
         else
             pip3 install --upgrade setuptools wheel pip
         fi
-        
+
         chown $synapse_user:root -R $final_path
         sudo -u $synapse_user env PATH=$PATH pip3 install --upgrade 'cryptography>=3.4.7'
         pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml jinja2
@@ -71,6 +71,6 @@ install_sources() {
 
 get_domain_list() {
     yunohost --output-as plain domain list | grep -E "^#" -v | sort | uniq | while read domain; do
-        echo -n "        - https://$domain\n"
+        echo -n "      - https://$domain\n"
     done
 }

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -49,7 +49,8 @@ synapse_db_name="matrix_$app"
 synapse_db_user="matrix_$app"
 synapse_db_name="matrix_$app"
 upstream_version=$(ynh_app_upstream_version)
-domain_whitelist_client=$(get_domain_list)
+domain_whitelist_client_=$(get_domain_list)
+domain_whitelist_client=${domain_whitelist_client_%"\n"}
 
 # Check if the new path stay /_matrix if not exit
 
@@ -113,6 +114,7 @@ else
     sso_enabled=False
 fi
 
+ynh_replace_string __DOMAIN_WHITELIST_CLIENT__ "$domain_whitelist_client" $YNH_APP_BASEDIR/conf/homeserver.yaml
 ynh_add_config --template="homeserver.yaml" --destination="/etc/matrix-$app/homeserver.yaml"
 ynh_add_config --template="log.yaml" --destination="/etc/matrix-$app/log.yaml"
 

--- a/scripts/config
+++ b/scripts/config
@@ -27,7 +27,8 @@ is_free_registration=$(ynh_app_setting_get --app $app --key is_free_registration
 jitsi_server=$(ynh_app_setting_get --app=$app --key=jitsi_server)
 e2e_enabled_by_default=$(ynh_app_setting_get --app=$app --key=e2e_enabled_by_default)
 synapse_user_app_pwd=$(ynh_app_setting_get --app=$app --key=synapse_user_app_pwd)
-domain_whitelist_client=$(get_domain_list)
+domain_whitelist_client_=$(get_domain_list)
+domain_whitelist_client=${domain_whitelist_client_%"\n"}
 main_domain=$(yunohost domain list --output-as json | jq -r .main)
 
 #=================================================
@@ -136,6 +137,7 @@ apply_config() {
         sso_enabled=False
     fi
 
+    ynh_replace_string __DOMAIN_WHITELIST_CLIENT__ "$domain_whitelist_client" $YNH_APP_BASEDIR/conf/homeserver.yaml
     ynh_add_config --template="homeserver.yaml" --destination="/etc/matrix-$app/homeserver.yaml"
     ynh_add_config --template="log.yaml" --destination="/etc/matrix-$app/log.yaml"
 

--- a/scripts/install
+++ b/scripts/install
@@ -36,7 +36,8 @@ report_stats="false"
 allow_public_rooms="false"
 e2e_enabled_by_default="true"
 default_domain_value="Same than the domain"
-domain_whitelist_client=$(get_domain_list)
+domain_whitelist_client_=$(get_domain_list)
+domain_whitelist_client=${domain_whitelist_client_%"\n"}
 
 #=================================================
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
@@ -277,6 +278,7 @@ else
     sso_enabled=False
 fi
 
+ynh_replace_string __DOMAIN_WHITELIST_CLIENT__ "$domain_whitelist_client" $YNH_APP_BASEDIR/conf/homeserver.yaml
 ynh_add_config --template="homeserver.yaml" --destination="/etc/matrix-$app/homeserver.yaml"
 ynh_add_config --template="log.yaml" --destination="/etc/matrix-$app/log.yaml"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -41,7 +41,8 @@ registration_shared_secret=$(ynh_app_setting_get --app=$app --key=registration_s
 form_secret=$(ynh_app_setting_get --app=$app --key=form_secret)
 macaroon_secret_key=$(ynh_app_setting_get --app=$app --key=macaroon_secret_key)
 synapse_user_app_pwd=$(ynh_app_setting_get --app=$app --key=synapse_user_app_pwd)
-domain_whitelist_client=$(get_domain_list)
+domain_whitelist_client_=$(get_domain_list)
+domain_whitelist_client=${domain_whitelist_client_%"\n"}
 main_domain=$(yunohost domain list --output-as json | jq -r .main)
 
 #=================================================
@@ -249,6 +250,7 @@ else
     sso_enabled=False
 fi
 
+ynh_replace_string __DOMAIN_WHITELIST_CLIENT__ "$domain_whitelist_client" "$YNH_APP_BASEDIR/conf/homeserver.yaml"
 ynh_add_config --template="homeserver.yaml" --destination="/etc/matrix-$app/homeserver.yaml"
 ynh_add_config --template="log.yaml" --destination="/etc/matrix-$app/log.yaml"
 


### PR DESCRIPTION
## Problem

- In the `homeserver.yaml` file, URLs in `sso/client_whitelist` are not well formatted: there are all in the same line instead of being a list, and this line is over-indented.

## Solution

- Remove the latest `\n` from the generated list of domains
- Replace the `__DOMAIN_WHITELIST_CLIENT__` var in the template before applying the template. Using `ynh_add_config` escapes `\n` whereas `ynh_replace_string` doesn't.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
