### PR TITLE
Fix starting of coturn-synapse service

### DIFF
--- a/conf/coturn-synapse.service
+++ b/conf/coturn-synapse.service
@@ -8,11 +8,10 @@ User=turnserver
 Group=turnserver
 Type=forking
 EnvironmentFile=/etc/default/coturn-__APP__
-PIDFile=/run/coturn-__APP__/turnserver.pid
+PIDFile=/run/coturn-__APP__.pid
 RuntimeDirectory=coturn-__APP__
 RuntimeDirectoryMode=0755
 ExecStart=/usr/bin/turnserver -o -c /etc/matrix-__APP__/coturn.conf $EXTRA_OPTIONS
-ExecStopPost=/bin/rm -f /run/coturn-__APP__/turnserver.pid
 Restart=on-abort
 
 LimitCORE=infinity

--- a/conf/turnserver.conf
+++ b/conf/turnserver.conf
@@ -24,7 +24,7 @@ no-multicast-peers
 no-cli
 
 log-file=/var/log/matrix-__APP__/turnserver.log
-pidfile=/run/coturn-__APP__/turnserver.pid
+pidfile=/run/coturn-__APP__.pid
 simple-log
 
 __TURN_EXTERNAL_IP__


### PR DESCRIPTION
## Problem

[@kavelach in the chatroom experiences](https://matrix.to/#/!GevpWevrsZKluNMXsY:pijean.ovh/$XtheXoDCEliAwVpI6xb9uS95BEq7tygkl4DYSWBCp-U?via=matrix.org&via=libera.chat&via=aria-net.org) an issue while starting the CoTURN server:

```
 coturn-synapse.service: Can't open PID file /run/coturn-synapse/turnserver.pid (yet?) after start: Operation not permitted.
```

## Solution

- `PIDFile` option in service conf file implies that Systemd will remove the file when the service is stopped. No need for the `ExecPostStop` command ([source](https://www.freedesktop.org/software/systemd/man/systemd.service.html?_sm_au_=iVVPn0fKjKMfGjZ7W0qjjK76QKc3c#PIDFile=))
- I'm guessing a part of the issue is relying on the PID being in a subdirectory of `/run/`. Let's avoid that.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
