### PR TITLE
Fix turnserver config for bullseye

### DIFF
--- a/conf/coturn-synapse.service
+++ b/conf/coturn-synapse.service
@@ -6,13 +6,9 @@ After=syslog.target network.target
 [Service]
 User=turnserver
 Group=turnserver
-Type=forking
+Type=simple
 EnvironmentFile=/etc/default/coturn-__APP__
-PIDFile=/run/coturn-__APP__/turnserver.pid
-RuntimeDirectory=coturn-__APP__
-RuntimeDirectoryMode=0755
-ExecStart=/usr/bin/turnserver -o -c /etc/matrix-__APP__/coturn.conf $EXTRA_OPTIONS
-ExecStopPost=/bin/rm -f /run/coturn-__APP__/turnserver.pid
+ExecStart=/usr/bin/turnserver -c /etc/matrix-__APP__/coturn.conf $EXTRA_OPTIONS --pidfile=
 Restart=on-abort
 
 LimitCORE=infinity
@@ -50,7 +46,7 @@ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
 CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
 CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
 CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
-CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG 
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

- Turnserver is brocken on bullseye

## Solution

- Fix and improve the systemd configuration.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
