### PR TITLE
disable-password-if-private

### DIFF
--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -2167,7 +2167,7 @@ __DOMAIN_WHITELIST_CLIENT__
 password_config:
    # Uncomment to disable password login
    #
-   #enabled: false
+   enabled: __PASSWORD_CONFIG_ENABLED__
 
    # Uncomment to disable authentication against the local password
    # database. This is ignored if `enabled` is false, and is only useful

--- a/scripts/install
+++ b/scripts/install
@@ -272,9 +272,11 @@ if [ $is_free_registration -eq 0 ]
 then
     allowed_access=False
     sso_enabled=True
+    password_config_enabled=False
 else
     allowed_access=True
     sso_enabled=False
+    password_config_enabled=True
 fi
 
 ynh_add_config --template="homeserver.yaml" --destination="/etc/matrix-$app/homeserver.yaml"


### PR DESCRIPTION
## Problem

- see https://github.com/YunoHost-Apps/synapse_ynh/issues/315

## Solution

- disable password login by default if synapse is installed as private app (registration disabled). We can suppose users will then only connect through the SSO/CAS

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
