### PR TITLE
turnserver.conf: remove no-loopback-peers

### DIFF
--- a/conf/turnserver.conf
+++ b/conf/turnserver.conf
@@ -18,7 +18,6 @@ no-sslv3
 no-tlsv1
 no-tlsv1_1
 
-no-loopback-peers
 no-multicast-peers
 
 no-cli


### PR DESCRIPTION
See https://github.com/coturn/coturn/commit/8a60754d709cd34936f73e4f71a618e38f81e045

Option removed in 4.5.2. This was a sane default before, but now coturn complains on startup that this option is invalid:
> Bad configuration format: no-loopback-peers

See also:
cve-2020-26262
https://github.com/coturn/coturn/security/advisories/GHSA-6g6j-r9rf-cm7p https://www.rtcsec.com/article/cve-2020-26262-bypass-of-coturns-access-control-protection/ https://www.mageni.net/vulnerability/coturn-452-loopback-bypass-vulnerability-145204

## Problem

- Fix warning in coturn log

## Solution

- Remove deprecated option from the config

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
