### PR TITLE
Prep app for YunoHost 11.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
         "code": "https://github.com/matrix-org/synapse"
     },
 	"requirements": {
-		"yunohost": ">= 4.1.2"
+		"yunohost": ">= 11.1"
 	},
 	"multi_instance": true,
 	"services": [

--- a/scripts/install
+++ b/scripts/install
@@ -146,7 +146,7 @@ ynh_install_app_dependencies $dependances
 ynh_script_progression --message="Configuring system user..." --weight=3
 
 ynh_system_user_create --username=$synapse_user --home_dir=$final_path
-yunohost user create $synapse_user_app -f Synapse -l Application -d $domain -p "$synapse_user_app_pwd"
+yunohost user create $synapse_user_app -F Synapse Application -d $domain -p "$synapse_user_app_pwd"
 adduser $synapse_user ssl-cert
 adduser turnserver ssl-cert
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -80,7 +80,7 @@ ynh_script_progression --message="Recreating the dedicated system user..." --wei
 
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$synapse_user --home_dir=$final_path
-yunohost user create $synapse_user_app -f Synapse -l Application -d $domain -p "$synapse_user_app_pwd"
+yunohost user create $synapse_user_app -F Synapse Application -d $domain -p "$synapse_user_app_pwd"
 adduser $synapse_user ssl-cert
 adduser turnserver ssl-cert
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -141,7 +141,7 @@ fi
 if [ -z $synapse_user_app_pwd ]; then
     synapse_user_app_pwd="$(ynh_string_random --length=30)"
     ynh_app_setting_set --app=$app --key=synapse_user_app_pwd --value=$synapse_user_app_pwd
-    yunohost user create $synapse_user_app -f Synapse -l Application -d $domain -p "$synapse_user_app_pwd"
+    yunohost user create $synapse_user_app -F Synapse Application -d $domain -p "$synapse_user_app_pwd"
 fi
 
 #=================================================


### PR DESCRIPTION
- `yunohost user create` command is now demanding a full name with the `-F` flag

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
