### PR TITLE
Fix upgrade with old pyopenssl

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -53,7 +53,7 @@ install_sources() {
         fi
         
         chown $synapse_user:root -R $final_path
-        sudo -u $synapse_user env PATH=$PATH pip3 install --upgrade 'cryptography>=3.4.7'
+        sudo -u $synapse_user env PATH=$PATH pip3 install --upgrade 'cryptography>=3.4.7' 'pyOpenSSL>=22.1.0'
         pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml jinja2
         # Fix issue https://github.com/YunoHost-Apps/synapse_ynh/issues/248
         pip3 install --upgrade 'Twisted>=21' 'treq>=21.1.0' matrix-synapse==$upstream_version matrix-synapse-ldap3


### PR DESCRIPTION
## Problem

- #355 

## Solution

- Force upgrade pyOpenssl

Note that we really should find a way to be sure that we have a clean version of each packages

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
