### PR TITLE
privacy : detailed push notif disabled by default

### DIFF
--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -2420,7 +2420,7 @@ push:
   # The default value is "true" to include message details. Uncomment to only
   # include the event ID and room ID in push notification payloads.
   #
-  #include_content: false
+  include_content: false
 
   # When a push notification is received, an unread count is also sent.
   # This number can either be calculated as the number of unread messages


### PR DESCRIPTION
## Problem

- when push notification is used (google play elementapp for example) private informations are leeked to google

## Solution

- disable detailed push notifications

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

