### PR TITLE
Fix setuptools version in _common.sh

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -48,7 +48,7 @@ install_sources() {
         set -$u_arg;
         if [ $(lsb_release --codename --short) == "bullseye" ]; then
             # Fix issue with setuptools https://github.com/pypa/setuptools/issues/3118
-            pip3 install --upgrade setuptools==60.8.2 wheel pip
+            pip3 install --upgrade setuptools==68.2.0 wheel pip
         else
             pip3 install --upgrade setuptools wheel pip
         fi


### PR DESCRIPTION
It seems there is a typo in the version number of setuptools.

It uninstalls the working version 68.2.0 and installs 60.8.2, breaking dependencies.

This breaks upgrade as well as restore, resulting in synapse no longer working at all.

```
023-10-03 19:49:12,259: DEBUG - + pip3 install --upgrade setuptools==60.8.2 wheel pip
2023-10-03 19:49:13,433: DEBUG - Collecting setuptools==60.8.2
2023-10-03 19:49:13,454: DEBUG -   Using cached setuptools-60.8.2-py3-none-any.whl (1.1 MB)
2023-10-03 19:49:13,463: DEBUG - Requirement already satisfied: wheel in /opt/yunohost/matrix-synapse/lib/python3.9/site-packages (0.41.2)
2023-10-03 19:49:13,525: DEBUG - Requirement already satisfied: pip in /opt/yunohost/matrix-synapse/lib/python3.9/site-packages (23.2.1)
2023-10-03 19:49:14,188: DEBUG - Installing collected packages: setuptools
2023-10-03 19:49:14,189: DEBUG -   Attempting uninstall: setuptools
2023-10-03 19:49:14,190: DEBUG -     Found existing installation: setuptools 68.2.0
2023-10-03 19:49:14,210: DEBUG -     Uninstalling setuptools-68.2.0:
2023-10-03 19:49:14,261: DEBUG -       Successfully uninstalled setuptools-68.2.0
2023-10-03 19:49:14,688: WARNING - ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
2023-10-03 19:49:14,688: WARNING - setuptools-rust 1.7.0 requires setuptools>=62.4, but you have setuptools 60.8.2 which is incompatible.
2023-10-03 19:49:14,688: DEBUG - Successfully installed setuptools-60.8.2
2023-10-03 19:49:14,927: DEBUG - + pip3 install --upgrade cffi ndg-httpsclient psycopg2 lxml jinja2
2023-10-03 19:49:15,312: DEBUG - Requirement already satisfied: cffi in /opt/yunohost/matrix-synapse/lib/python3.9/site-packages (1.15.1)
2023-10-03 19:49:15,700: DEBUG - Collecting cffi
2023-10-03 19:49:15,700: DEBUG -   Obtaining dependency information for cffi from https://files.pythonhosted.org/packages/ea/ac/e9e77bc385729035143e54cc8c4785bd480eaca9df17565963556b0b7a93/cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
2023-10-03 19:49:15,871: DEBUG -   Downloading cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
2023-10-03 19:49:15,882: DEBUG - Requirement already satisfied: ndg-httpsclient in /opt/yunohost/matrix-synapse/lib/python3.9/site-packages (0.5.1)
2023-10-03 19:49:15,904: DEBUG - Requirement already satisfied: psycopg2 in /opt/yunohost/matrix-synapse/lib/python3.9/site-packages (2.9.7)
2023-10-03 19:49:16,003: DEBUG - Collecting psycopg2
2023-10-03 19:49:16,014: DEBUG -   Downloading psycopg2-2.9.9.tar.gz (384 kB)
2023-10-03 19:49:16,050: DEBUG -      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 384.9/384.9 kB 11.7 MB/s eta 0:00:00
2023-10-03 19:49:16,104: DEBUG -   Preparing metadata (setup.py): started
2023-10-03 19:49:16,387: DEBUG -   Preparing metadata (setup.py): finished with status 'error'
2023-10-03 19:49:16,391: WARNING -   error: subprocess-exited-with-error
2023-10-03 19:49:16,391: DEBUG - 
2023-10-03 19:49:16,391: WARNING -   × python setup.py egg_info did not run successfully.
```

Please review.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
