### PR TITLE
Testing

### DIFF
--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -304,7 +304,7 @@ listeners:
     tls: false
     type: http
     x_forwarded: true
-    bind_addresses: ['::1', '127.0.0.1']
+    bind_addresses: [localhost]
 
     resources:
       - names: [client, federation]

--- a/conf/synapse-coturn.service
+++ b/conf/synapse-coturn.service
@@ -8,7 +8,7 @@ User=turnserver
 Group=turnserver
 Type=notify
 EnvironmentFile=/etc/matrix-__APP__/coturn_env
-ExecStart=/usr/bin/turnserver -c /etc/matrix-__APP__/coturn.conf $EXTRA_OPTIONS --pidfile=
+ExecStart=/usr/bin/turnserver -c /etc/matrix-__APP__/coturn.conf $EXTRA_OPTIONS -L 0.0.0.0 --pidfile=
 Restart=on-failure
 InaccessibleDirectories=/home
 PrivateTmp=yes


### PR DESCRIPTION
## Problem

- synapse-coturn service does not start at boot
- synapse service does not start on ipv4 only server

synapse-coturn error (this error happens only at boot time. if the service is manually starter later on, there is no error) : 
```
May 02 22:22:31 domain.tld turnserver[1003]: 0: : NO EXPLICIT LISTENER ADDRESS(ES) ARE CONFIGURED
May 02 22:22:31 domain.tld turnserver[1003]: 0: : ===========Discovering listener addresses: =========
May 02 22:22:31 domain.tld turnserver[1003]: 0: : Listener address to use: 127.0.0.1
May 02 22:22:31 domain.tld turnserver[1003]: 0: : ERROR: main: Cannot configure any meaningful IP listener address
```
synapse error (this error happen on servers that do not have ipv6 enabled : 
```
May 03 14:08:34 domain.tld python[285652]: twisted.internet.error.CannotListenError: Couldn't listen on ::1:8008: [Errno 99] Cannot assign requested address.
```


## Solution

- for synapse-coturn service error, added the option `-L 0.0.0.0` on `ExecStart` line in systemd unit file
- for synapse service error, changed the listening address to `localhost` instead of `::1` and `127.0.0.1`

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [x ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
