### PR TITLE
Fix bookworm ci

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -147,7 +147,7 @@ ynh_script_progression --message="Configuring NGINX web server..." --weight=2
 # Create a dedicated php-fpm config
 ynh_script_progression --message="Configuring application..."
 
-ynh_add_fpm_config --usage=low --footprint=low
+ynh_add_fpm_config --usage=low --footprint=low --phpversion=$phpversion
 
 configure_nginx
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -242,6 +242,16 @@ if grep -q "^matrix-$app" /etc/passwd; then
 fi
 
 #=================================================
+# MIGRATION 13 : set PHP version if unset
+#=================================================
+
+# If phpversion doesn't exist, create it
+if [ -z "${phpversion:-}" ]; then
+	phpversion=8.3
+	ynh_app_setting_set --app=$app --key=phpversion --value=$phpversion
+fi
+
+#=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -302,7 +302,7 @@ ynh_script_progression --message="Upgrading NGINX web server configuration..." -
 # Create a dedicated php-fpm config
 ynh_script_progression --message="Configuring application..."
 
-ynh_add_fpm_config --usage=low --footprint=low
+ynh_add_fpm_config --usage=low --footprint=low --phpversion=$phpversion
 
 configure_nginx
 

--- a/tests.toml
+++ b/tests.toml
@@ -4,6 +4,6 @@ test_format = 1.0
 
 [default]
 
-    test_upgrade_from.63e05d642565e6e9f9e5faae3addf3808b77ac49.name = "Post app user creation (branch old_version_for_CI_7)"
+    test_upgrade_from.672791a51c1d239918562d7a0d4420ec137e6694.name = "Post app user creation (branch old_version_for_CI_7)" 
 
-    test_upgrade_from.7cf8ba9549a999b754a67f2d9ab15b846f077fdd.name = "Before packaging v2 (branch old_version_for_CI_6)"
+    test_upgrade_from.971f2eb590325fb1d6e1ca5723f59aacd639c9ce.name = "Before packaging v2 (branch old_version_for_CI_6)"


### PR DESCRIPTION
## Problem

Bookworm CI failing. See https://github.com/YunoHost-Apps/synapse_ynh/pull/484#issuecomment-2309445560

## Solution

Explicitly define PHP version during install and upgrade processes.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
