### PR TITLE
We should show 3pid parameter also when we don't allow registration

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -33,13 +33,11 @@ services = ["__APP__"]
         ask = "Register only with given email formats"
         type = "tags"
         help = '( e.g. ^[^@]+@matrix\\.org$ )'
-        visible = 'enable_registration && (registrations_require_3pid == "email" || registrations_require_3pid == "email&msisdn")'
 
         [main.welcome.allowed_local_3pids_msisdn]
         ask = "Register only with given phone number formats"
         type = "tags"
         help = '( e.g. \\+33 )'
-        visible = 'enable_registration && (registrations_require_3pid == "email&msisdn" || registrations_require_3pid == "msisdn")'
 
         [main.welcome.disable_msisdn_registration]
         ask = "Disable asking Phone Number in Registration flow"
@@ -162,17 +160,6 @@ services = ["__APP__"]
 [advanced]
 name = "Advanced Settings"
 services = ["__APP__"]
-
-    # Disabled as it don't work any more on bookworm
-    #
-    # [advanced.help]
-    # name = "SETTINGS FOR EXPERTS IN SERVER ADMINISTRATION"
-    #
-    #     [advanced.help.text]
-    #     ask = '''
-    #     !!There are security and privacy risks if you change these settings without knowing what you do!!
-    #     '''
-    #     type = "markdown"
 
     [advanced.others]
     name = "Others"

--- a/scripts/config
+++ b/scripts/config
@@ -11,8 +11,6 @@ ynh_app_config_validate() {
         password_enabled=true
     else
         registrations_require_3pid=email
-        allowed_local_3pids_email=''
-        allowed_local_3pids_msisdn=''
         disable_msisdn_registration=true
     fi
     if ! $enable_notifs; then


### PR DESCRIPTION
## Problem

-  The 3pids email and phone number should be editable even if the free registration settings is disabled

## Solution

- Enable in all cases

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
