### PR TITLE
Cleanup legacy label parameter for dynamic permissions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -190,8 +190,8 @@ ynh_script_progression "Configuring permissions..."
 
 if yunohost --output-as plain domain list | grep -q "^$server_name$"; then
     ynh_""permission_create --permission=server_client_infos --url="$server_name"/.well-known/matrix \
-                          --label="Server info for clients. (well-known)" --show_tile=false --allowed=visitors \
-                          --auth_header=false --protected=true
+                            --show_tile=false --allowed=visitors \
+                            --auth_header=false --protected=true
 else
     ynh_print_warn "Note yunohost won't be able to manage the required config for $server_name. So please add the needed DNS config as described on the documentation"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -355,13 +355,13 @@ ynh_script_progression "Configuring permissions..."
 if yunohost --output-as plain domain list | grep -q "^$server_name"'$'; then
     if ! ynh_""permission_exists --permission=server_client_infos; then
         ynh_""permission_create --permission=server_client_infos --url="$server_name"/.well-known/matrix \
-                              --label="Server info for clients. (well-known)" --show_tile=false --allowed=visitors \
-                              --auth_header=false --protected=true
+                                --show_tile=false --allowed=visitors \
+                                --auth_header=false --protected=true
     else yunohost --output-as plain domain list | grep -q "^$server_name"'$'
         ynh_""permission_url --permission=server_client_infos --url="$server_name"/.well-known/matrix \
                           --auth_header=false
-        ynh_""permission_update --permission=server_client_infos --label="Server info for clients. (well-known)" --show_tile=false \
-                              --protected=true
+        ynh_""permission_update --permission=server_client_infos --show_tile=false \
+                                --protected=true
     fi
 fi
 


### PR DESCRIPTION
## Problem

- #518

## Solution

- Cleanup the label parameter for the dynamic permissions

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
