### PR TITLE
Support livekit

### DIFF
--- a/conf/server_name.conf
+++ b/conf/server_name.conf
@@ -8,7 +8,13 @@ location = /.well-known/matrix/client {
     return 200 '{
         "m.homeserver": { "base_url": "https://__DOMAIN__" },
         "im.vector.riot.jitsi": {"preferredDomain": "__JITSI_SERVER__"},
-        "im.vector.riot.e2ee": {"default": __E2E_ENABLED_BY_DEFAULT_CLIENT_CONFIG__ }
+        "im.vector.riot.e2ee": {"default": __E2E_ENABLED_BY_DEFAULT_CLIENT_CONFIG__ },
+        "org.matrix.msc4143.rtc_foci": [
+         {
+          "type": "livekit",
+          "livekit_service_url": "https://__LIVEKIT_SERVER__"
+         }
+        ] 
     }';
     add_header Content-Type application/json;
     add_header Access-Control-Allow-Origin '*';

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,6 +55,13 @@ ram.runtime = "1G"
     example = "domain.org"
     default = "jitsi.riot.im"
 
+    [install.livekit_server]
+    ask.en = "Livekit server address for conferencing?"
+    ask.fr = "Adresse du serveur Livekit pour les conférences ?"
+    type = "string"
+    example = "domain.org"
+    default = "livekit-jwt.call.matrix.org"
+
     [install.init_main_permission]
     help.en = "Define the users allowed to access to synapse. Setting this to 'visitors' don't make sens in this case."
     type = "group"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -31,7 +31,10 @@ ensure_vars_set
 ynh_app_setting_set_default --app="$app" --key=server_name --value="$domain"
 
 # Define $jitsi_server if not already defined
-ynh_app_setting_set_default --app="$app" --key=jitsi_server --value='jitsi.riot.im'
+ynh_app_setting_set_default --app="$app" --key=jitsi_server --value='jitsi.riot.i'
+
+# Define $livekit_server if not already defined
+ynh_app_setting_set_default --app="$app" --key=livekit_server --value='livekit-jwt.call.matrix.org"'
 
 if [ "$e2e_enabled_by_default" = "true" ] ; then
     e2e_enabled_by_default="all"


### PR DESCRIPTION
## Problem

- It looks like Livekit is going to replace Jitsi

## Solution

- Follow instructions from https://element.io/blog/end-to-end-encrypted-voice-and-video-for-self-hosted-community-users/

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
