### PR TITLE
Add setting to allow request on localhost

### DIFF
--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -84,7 +84,6 @@ allow_public_rooms_over_federation: {{ allow_public_rooms_over_federation }}
 # Note: The value is ignored when an HTTP proxy is in use
 #
 ip_range_blacklist:
- - '127.0.0.0/8'
  - '10.0.0.0/8'
  - '172.16.0.0/12'
  - '192.168.0.0/16'
@@ -97,12 +96,15 @@ ip_range_blacklist:
  - '198.51.100.0/24'
  - '203.0.113.0/24'
  - '224.0.0.0/4'
- - '::1/128'
  - 'fe80::/10'
  - 'fc00::/7'
  - '2001:db8::/32'
  - 'ff00::/8'
  - 'fec0::/10'
+{%- if allow_to_send_request_to_localhost != 'true' %}
+ - '127.0.0.0/8'
+ - '::1/128'
+{% endif %}
 
 # List of ports that Synapse should listen on, their purpose and their
 # configuration.

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -234,3 +234,10 @@ services = ["__APP__"]
             yes = "true"
             no = "false"
             help = "Enabling TLS/DTLS is really recommanded but it could bring some issues depending of the server certificate. There are some known issues with let's encrypt (https://github.com/element-hq/element-android/issues/1533), so if you have issues it could be better to disable this feature."
+
+            [advanced.security.allow_to_send_request_to_localhost]
+            ask = "Allow synapse to send request to localhost"
+            type = "boolean"
+            yes = "true"
+            no = "false"
+            help = "This could be needed by example if you self host on the same Yunohost instance a ntfy server for notifications. In this case to allow synapse to contact the ntfy server you will need to enable this settings."

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -176,6 +176,7 @@ ensure_vars_set() {
     ynh_app_setting_set_default --app="$app" --key=enable_3pid_lookup --value=false
     ynh_app_setting_set_default --app="$app" --key=push_include_content --value=true
     ynh_app_setting_set_default --app="$app" --key=enable_dtls_for_audio_video_turn_call --value=true
+    ynh_app_setting_set_default --app="$app" --key=allow_to_send_request_to_localhost --value=false
 
     ynh_app_setting_set_default --app="$app" --key=livekit_secret --value="$(ynh_string_random --length=40)"
 }


### PR DESCRIPTION
## Problem
- The [ntfy app](https://github.com/YunoHost-Apps/ntfy_ynh) don't work with synapse because synapse refuse to send request on ntfy because it's on the same host.

## Solution
- Add a settings to allow it. Allowing it by default could be considered as a security breach, so a settings bring more flexibility around this.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
