### PR TITLE
Drop support for Yunohost 11

### DIFF
--- a/auto_update/auto_update.sh
+++ b/auto_update/auto_update.sh
@@ -4,7 +4,7 @@ set -eu
 
 readonly app_name=synapse
 
-readonly debian_version_name_1=bullseye
+readonly debian_version_name_1=trixie
 readonly debian_version_name_2=bookworm
 
 source auto_update_config.sh

--- a/conf/requirement_trixie.txt
+++ b/conf/requirement_trixie.txt
@@ -51,7 +51,6 @@ setuptools-rust==1.11.1
 signedjson==1.1.4
 six==1.17.0
 sortedcontainers==2.4.0
-tomli==2.2.1
 treq==25.5.0
 Twisted==24.11.0
 typing-inspection==0.4.1

--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,7 @@ cpe = "cpe:2.3:a:matrix:synapse"
 fund = "https://matrix.org/support/#"
 
 [integration]
-yunohost = ">= 11.2.30"
+yunohost = ">= 12.0.12"
 helpers_version = "2.1"
 architectures = [
     "amd64",


### PR DESCRIPTION
## Problem

- #548 

## Solution

- Drop support for ynh11

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
