### PR TITLE
Fix typo in backup message

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -9,7 +9,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 if systemctl is-active "$app".service --quiet; then
-    ynh_print_warn "It's hightly recommended to make your backup when the service is stopped. Please stop $app service with this command before to run the backup 'systemctl stop $app.service'"
+    ynh_print_warn "It's highly recommended to make your backup when the service is stopped. Please stop $app service with this command before to run the backup 'systemctl stop $app.service'"
 fi
 
 ynh_print_info "Declaring files to be backed up..."


### PR DESCRIPTION
## Problem

- To fix a small typo in a message displayed while creating a backup of the application

## Solution

- Fix the typo

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
