### PR TITLE
feat: Turn on push notifications for encrypted events (MSC 4028)

### DIFF
--- a/conf/homeserver.yaml
+++ b/conf/homeserver.yaml
@@ -1018,6 +1018,8 @@ experimental_features:
     msc4222_enabled: true
     # MSC4140: Delayed events are required for proper call participation signalling. If disabled it is very likely that you end up with stuck calls in Matrix rooms
     msc4140_enabled: true
+    # MSC 4028: Turn on push notifications for encrypted messages
+    msc4028_push_encrypted_events: true
 
 # The maximum allowed duration by which sent events can be delayed, as
 # per MSC4140.


### PR DESCRIPTION
Copy of #581

## Problem

Push notifications are not sent for encrypted events. If only an encrypted event is received (no other events), no push notifications are sent by default.

In a private encrypted room, that means we can miss messages because no notifications were sent.

See discussion on https://github.com/element-hq/element-x-ios/issues/2411, changelog on pro suite too: https://docs.element.io/latest/element-server-suite-pro/release-notes/#changed_2

## Solution

- Enable MSC4028 experimental feature

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
