### PR TITLE
Update go version to 1.25

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -162,4 +162,4 @@ ram.runtime = "1G"
     type = "postgresql"
 
     [resources.go]
-    version = "1.24.2"
+    version = "1.25"


### PR DESCRIPTION
## Problem

The latest stable go version is 1.25, see https://go.dev/dl/
Also, if the minor version is hardcoded like `1.24.2` instead of `1.24` not the latest version is being used (last stable `1.24.x` version is `1.24.12`)

## Solution

Update go to `1.25` (expected to pull `1.25.6` as of today). 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
