### PR TITLE
Update PHP to version 8.5

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -154,7 +154,7 @@ ram.runtime = "3G"
     livekit_jwt.default = 8080
 
     [resources.apt]
-    packages = ["coturn", "acl", "postgresql", "php8.4-fpm",
+    packages = ["coturn", "acl", "postgresql", "php8.5-fpm",
                 "python3-dev", "python3-venv", "python3-pip", "python3-setuptools", "python3-lxml",
                 "build-essential", "libffi-dev", "libssl-dev", "libxml2-dev", "libxslt1-dev", "zlib1g-dev", "libjpeg-dev", "libpq-dev"]
 


### PR DESCRIPTION
## Problem

Follow up of https://github.com/YunoHost-Apps/synapse_ynh/pull/601 to update PHP to its latest stable version.

## Solution

Update PHP to version 8.5.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
