### PR TITLE
[fix] Full disk when db down

### DIFF
--- a/conf/log.yaml
+++ b/conf/log.yaml
@@ -48,13 +48,15 @@ handlers:
         formatter: precise
 
 loggers:
+    synapse:
+        level: ERROR
     synapse.storage.SQL:
         # beware: increasing this to DEBUG will make synapse log sensitive
         # information such as access tokens.
-        level: INFO
+        level: ERROR
 
 root:
-    level: INFO
+    level: ERROR
 
     # Write logs to the `buffer` handler, which will buffer them together in memory,
     # then write them to a file.


### PR DESCRIPTION
## Problem
When db is down (for example due to oem_killer), synapse write a tons of stacktrace about not being able to join database, this fill quickly the disk.

## Solution

Reduce logs level 

## PR Status
Tested on a prod, but need to be validated...

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
